### PR TITLE
Fixed typo in tables

### DIFF
--- a/guides/tools/en/island scan pokemon - sm.md
+++ b/guides/tools/en/island scan pokemon - sm.md
@@ -6,7 +6,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/f/f5/158MS.png) | Totodile       | Seaward Cave     |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/4/43/363MS.png) | Spheal         | Route 7          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/1/10/220MS.png) | Swinub         | Tapu Village     |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/1/10/220MS.png) | Swinub         | Tapu Village     |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/8/8b/534MS.png) | Conkeldurr	   | Poni Plains      |
 
 ## Tuesday
@@ -15,7 +15,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/3/39/633MS.png) | Deino          | Ten Carat Hill   |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/e/e3/404MS.png) | Luxio          | Route 8          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/6/64/578MS.png) | Duosion        | Route 16         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/6/64/578MS.png) | Duosion        | Route 16         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/6/63/468MS.png) | Togekiss       | Poni Gauntlet    |
 
 ## Wednesday
@@ -24,7 +24,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/2/23/116MS.png) | Horsea         | Kala'e Bay       |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/0/04/679MS.png) | Honedge        | Akala Outskirts  |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/b/bf/315MS.png) | Roselia        | Ula'ula Meadow   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/b/bf/315MS.png) | Roselia        | Ula'ula Meadow   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/2/2d/542MS.png) | Leavanny       | Poni Meadow      |
 
 ## Thursday
@@ -33,7 +33,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/6/61/599MS.png) | Klink          | Hau'oli City     |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/2/2c/543MS.png) | Venipede       | Route 4          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/e/e2/397MS.png) | Staravia       | Route 10         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/e/e2/397MS.png) | Staravia       | Route 10         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/2/2e/497MS.png) | Serperior      | Exeggutor Island |
 
 ## Friday
@@ -42,7 +42,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/7/79/152MS.png) | Chikorita      | Route 2          |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/7/7b/069MS.png) | Bellsprout     | Route 5          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/3/38/288MS.png) | Vigoroth       | Route 11         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/3/38/288MS.png) | Vigoroth       | Route 11         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/9/99/503MS.png) | Samurott       | Poni Wilds       |
 
 ## Saturday
@@ -51,7 +51,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/7/7c/607MS.png) | Litwick        | Hau'oli Cemetery |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/3/36/183MS.png) | Marill         | Brooklet Hill    |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/0/0c/610MS.png) | Axew           | Mount Hokulani   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/0/0c/610MS.png) | Axew           | Mount Hokulani   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/b/be/500MS.png) | Emboar         | Ancient Poni Path|
 
 ## Sunday
@@ -60,5 +60,5 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/3/39/155MS.png) | Cyndaquil      | Route 3          |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/5/57/574MS.png) | Gothita        | Route 6          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/6/67/111MS.png) | Rhyorn         | Blush Mountain   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/6/67/111MS.png) | Rhyorn         | Blush Mountain   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/0/0f/604MS.png) | Eelektross     | Poni Grove       |

--- a/guides/tools/en/island scan pokemon - usum.md
+++ b/guides/tools/en/island scan pokemon - usum.md
@@ -6,7 +6,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/9/92/007MS.png) | Squirtle       | Seaward Cave     |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/4/43/363MS.png) | Spheal         | Route 7          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/1/10/220MS.png) | Swinub         | Tapu Village     |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/1/10/220MS.png) | Swinub         | Tapu Village     |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/d/d5/306MS.png) | Aggron	       | Poni Plains      |
 
 ## Tuesday
@@ -15,7 +15,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/c/cd/095MS.png) | Onix           | Ten Carat Hill   |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/4/4d/256MS.png) | Combusken      | Route 8          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/a/a3/394MS.png) | Prinplup       | Route 16         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/a/a3/394MS.png) | Prinplup       | Route 16         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/1/14/479MS.png) | Rotom          | Poni Gauntlet    |
 
 ## Wednesday
@@ -24,7 +24,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/2/23/116MS.png) | Horsea         | Kala'e Bay       |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/0/04/679MS.png) | Honedge        | Akala Outskirts  |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/4/40/388MS.png) | Grotle         | Ula'ula Meadow   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/4/40/388MS.png) | Grotle         | Ula'ula Meadow   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/2/2d/542MS.png) | Leavanny       | Poni Meadow      |
 
 ## Thursday
@@ -33,7 +33,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/e/e0/664MS.png) | Scatterbug     | Hau'oli City     |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/5/5a/015MS.png) | Beedrill       | Route 4          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/6/68/018MS.png) | Pidgeot        | Route 10         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/6/68/018MS.png) | Pidgeot        | Route 10         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/1/1c/652MS.png) | Chesnaught     | Exeggutor Island |
 
 ## Friday
@@ -42,7 +42,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/e/ec/001MS.png) | Bulbasaur      | Route 2          |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/a/a5/253MS.png) | Grovyle        | Route 5          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/7/70/391MS.png) | Monferno       | Route 11         |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/7/70/391MS.png) | Monferno       | Route 11         |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/8/87/658MS.png) | Greninja       | Poni Wilds       |
 
 ## Saturday
@@ -51,7 +51,7 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/7/7c/607MS.png) | Litwick        | Hau'oli Cemetery |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/2/21/259MS.png) | Marshtomp      | Brooklet Hill    |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/0/0c/610MS.png) | Axew           | Mount Hokulani   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/0/0c/610MS.png) | Axew           | Mount Hokulani   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/f/f8/655MS.png) | Delphox        | Ancient Poni Path|
 
 ## Sunday
@@ -60,5 +60,5 @@
 | :------------- | :-------------                                         | :------------- | :-------------   |
 | Melemele       | ![](https://cdn.bulbagarden.net/upload/b/bb/004MS.png) | Charmander     | Route 3          |
 | Akala          | ![](https://cdn.bulbagarden.net/upload/3/32/280MS.png) | Ralts          | Route 6          |
-| Ula'ulam       | ![](https://cdn.bulbagarden.net/upload/6/67/111MS.png) | Rhyorn         | Blush Mountain   |
+| Ula'ula       | ![](https://cdn.bulbagarden.net/upload/6/67/111MS.png) | Rhyorn         | Blush Mountain   |
 | Poni           | ![](https://cdn.bulbagarden.net/upload/0/0f/604MS.png) | Eelektross     | Poni Grove       |


### PR DESCRIPTION
Fixed a typo on both resource pages where Ula'ula was spelled Ula'ulam

# Guide Details

## I want to (select one)

- [ ] Add a guide
- [x] Modify an existing guide

## Games affected

- SM/USUM

## Type of RNG

Island scan resources

## Language

English

## Notes

Fixed a type of Ula'ula on all tables
