### PR TITLE
Fix broken links to other guides

### DIFF
--- a/guides/rse/en/Live Battery TID RNG.md
+++ b/guides/rse/en/Live Battery TID RNG.md
@@ -12,7 +12,7 @@
 - [runasdate (Optional)](https://runasdate.en.softonic.com/)
 
 ## Reasons to RNG Your ID
-This guide will help you obtain cool TIDs for your RNG purposes. If you do not care about TID, I recommend that you do [Dead Battery TID/SID Abuse](https://pokemonrng.com/guides/rse/en/Ruby-Sapphire%20Dead%20Battery%20TID%20RNG.md), as it has far fewer steps and is much simpler. ```Certain TID/SID combos are not possible, but there are 8 SIDs you can use to obtain a Shiny. As such, this shouldn't be an issue.```
+This guide will help you obtain cool TIDs for your RNG purposes. If you do not care about TID, I recommend that you do [Dead Battery TID/SID Abuse](https://pokemonrng.com/guides/rse/en/Dead%20Battery%20TID%20RNG.md), as it has far fewer steps and is much simpler. ```Certain TID/SID combos are not possible, but there are 8 SIDs you can use to obtain a Shiny. As such, this shouldn't be an issue.```
 Onto the RNG Proccess!
 
 ## How To RNG TID in Ruby & Sapphire

--- a/guides/sm/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/sm/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -95,7 +95,7 @@ With PCalc you can check which frame you are on by looking at your egg seeds ing
 4. Follow the steps below to create a timeline to obtain the ESV you want.
     - Check the "Main RNG Egg (PID)" box in 3DSRNGTool under "Current Status". 
     - Afterwards reset "Filters" by clicking on the gear icon.
-    - Then follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline.
+    - Then follow the [timeline guide](https://pokemonrng.com/guides/sm/en/Timeline%20Guide.md) to create a timeline.
     - Creating a timeline is necessary to know what frames you can actually land on due to NPC influence on frames.
 
 5. After making a timeline you can now search for a target frame that you are able to land on.

--- a/guides/sm/en/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/sm/en/How to Find Egg Seeds Without Custom Firmware.md
@@ -62,7 +62,7 @@ The gift Eevee egg from the nursery does not count!
     - If the nature does not match, then your egg seeds were not correct. You will have to redo the 127 eggs again to get correct egg seeds.
     - You can right click on the frame that matched and choose "Set as Current Status" to update the "Current Status" with your egg seeds.
 
-8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/egg%20masuda%20method-shiny%20charm.md).  
+8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm.md).  
 
 ## Setup for 8 Egg Method
 
@@ -97,4 +97,4 @@ The gift Eevee egg does not count!
 4. Check the 8 eggs you hatched against the 8 eggs info in the output. If the natures and genders match for all 8 eggs then you have the correct egg seeds.
     - If they do not match then you will have to redo the 8 eggs again. Double check that the correct natures are entered in the order you accepted the eggs.
 
-5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/egg%20masuda%20method-shiny%20charm.md).  
+5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm.md).  

--- a/guides/sm/en/Island Scan RNG.md
+++ b/guides/sm/en/Island Scan RNG.md
@@ -11,7 +11,7 @@ _Easy shinies in apricorn balls_
   - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - The `honey` item
 - Have started an `Island Scan` and know the Pokemon you've scanned for
-  - [List of Island Scan islands and days for SM](https://pokemonrng.com/guides/tools/en/island%20scan%20pokemon%20-%20sm.md)
+  - [List of Island Scan islands and days for SM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20SM.md)
 
 ```
 Note: You can get the "honey" item in any store after clearing three trials.
@@ -48,7 +48,7 @@ Note: You can find your TSV in PCalc in the Game Info window. Press "Start + Up"
 
 #### On the right of 3DSRNGTool
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/Timeline%20Guide.md) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
 2. You should now have a target frame you wish to hit.
 
 

--- a/guides/sm/en/Mystery Gift (Event) RNG.md
+++ b/guides/sm/en/Mystery Gift (Event) RNG.md
@@ -39,7 +39,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 
 ## Step 2: RNGing the Pokemon
 
-- Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/sm/en/timeline.md)
+- Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/sm/en/Timeline%20Guide.md)
 
 - Advance to your target frame and when you land on it, press A to unpause the game and obtain the Pokemon.
 

--- a/guides/sm/en/RNGing Without Custom Firmware.md
+++ b/guides/sm/en/RNGing Without Custom Firmware.md
@@ -92,7 +92,7 @@ In summary, the total time span in seconds = (Pre-Timer + Lag) / 1000 + (Target 
 
 ### Step 1: Find initial seed via continue screen clock needles
 
-- Check [here](https://pokemonrng.com/guides/tools/en/init-seed-stock.md)
+- Check [here](https://pokemonrng.com/guides/tools/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md)
 - Once you get only one seed result, the tool will update it to main window. The starting frame in Time Calculator is updated as well. (417/477 + the number of frames you saw for clocks)
 - Be sure to double check your seed, most of failures are from the wrong seed ;)
 - Do not enter your save yet.

--- a/guides/sm/en/Stationary RNG.md
+++ b/guides/sm/en/Stationary RNG.md
@@ -9,9 +9,9 @@
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.
 
-If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://pokemonrng.com/guides/sm/en/mysterygift.md) instead.
+If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://pokemonrng.com/guides/sm/en/Mystery%20Gift%20(Event)%20RNG.md) instead.
 
-If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/stationary%20wormhole.md) instead.
+If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG.md) instead.
 
 ## Stationary Pokemon
   - Tapus: Tapu Koko, Tapu Lele, Tapu Bulu, Tapu Fini
@@ -56,7 +56,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 
 ## Step 2 (with NPCs): Create a Timeline
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/Timeline%20Guide.md) to create a timeline and find a target frame.
 
 ## Step 3: Obtaining the wanted Pokemon
 

--- a/guides/sm/en/Wild RNG.md
+++ b/guides/sm/en/Wild RNG.md
@@ -51,7 +51,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 Note: If you are in an area with 0 NPCs, there will not be a "Safe F Only" option. Do not check the "Blink F Only" box. Skip to the 0 NPC section instead. If there are NPCs, make sure to follow the rest of this section.
 ```
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/Timeline%20Guide.md) to create a timeline and find a target frame.
     - Before making the timeline, open the in game menu with `X` and have the cursor hover over the bag.
 
 ## Step 3: Obtaining the wanted Pokemon

--- a/guides/usum/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/usum/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -95,7 +95,7 @@ With PCalc you can check which frame you are on by looking at your egg seeds ing
 4. Follow the steps below to create a timeline to obtain the ESV you want.
     - Check the "Main RNG Egg (PID)" box in 3DSRNGTool under "Current Status". 
     - Afterwards reset "Filters" by clicking on the gear icon.
-    - Then follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline.
+    - Then follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) to create a timeline.
     - Creating a timeline is necessary to know what frames you can actually land on due to NPC influence on frames.
 
 5. After making a timeline you can now search for a target frame that you are able to land on.

--- a/guides/usum/en/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/usum/en/How to Find Egg Seeds Without Custom Firmware.md
@@ -62,7 +62,7 @@ The gift Eevee egg from the nursery does not count!
     - If the nature does not match, then your egg seeds were not correct. You will have to redo the 127 eggs again to get correct egg seeds.
     - You can right click on the frame that matched and choose "Set as Current Status" to update the "Current Status" with your egg seeds.
 
-8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/egg%20masuda%20method-shiny%20charm.md).  
+8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm.md).  
 
 ## Setup for 8 Egg Method
 
@@ -97,4 +97,4 @@ The gift Eevee egg does not count!
 4. Check the 8 eggs you hatched against the 8 eggs info in the output. If the natures and genders match for all 8 eggs then you have the correct egg seeds.
     - If they do not match then you will have to redo the 8 eggs again. Double check that the correct natures are entered in the order you accepted the eggs.
 
-5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/sm/en/egg%20masuda%20method-shiny%20charm.md).  
+5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm.md).  

--- a/guides/usum/en/Island Scan.md
+++ b/guides/usum/en/Island Scan.md
@@ -11,7 +11,7 @@ _Easy shinies in apricorn balls_
   - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - The `honey` item
 - Have started an `Island Scan` and know the Pokemon you've scanned for
-  - [List of Island Scan islands and days for USUM](https://pokemonrng.com/guides/tools/en/island%20scan%20pokemon%20-%20usum.md)
+  - [List of Island Scan islands and days for USUM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20USUM.md)
 
 ```
 Note: You can get the "honey" item in any store after clearing three trials.
@@ -48,7 +48,7 @@ Note: You can find your TSV in PCalc in the Game Info window. Press "Start + Up"
 
 #### On the right of 3DSRNGTool
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
 2. You should now have a target frame you wish to hit.
 
 

--- a/guides/usum/en/Mystery Gift (Event) RNG.md
+++ b/guides/usum/en/Mystery Gift (Event) RNG.md
@@ -39,7 +39,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 
 ## Step 2: RNGing the Pokemon
 
-- Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/sm/en/timeline.md)
+- Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md)
 
 - Advance to your target frame and when you land on it, press A to unpause the game and obtain the Pokemon.
 

--- a/guides/usum/en/RNGing Without Custom Firmware.md
+++ b/guides/usum/en/RNGing Without Custom Firmware.md
@@ -92,7 +92,7 @@ In summary, the total time span in seconds = (Pre-Timer + Lag) / 1000 + (Target 
 
 ### Step 1: Find initial seed via continue screen clock needles
 
-- Check [here](https://pokemonrng.com/guides/tools/en/init-seed-stock.md)
+- Check [here](https://pokemonrng.com/guides/tools/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md)
 - Once you get only one seed result, the tool will update it to main window. The starting frame in Time Calculator is updated as well. (417/477 + the number of frames you saw for clocks)
 - Be sure to double check your seed, most of failures are from the wrong seed ;)
 - Do not enter your save yet.

--- a/guides/usum/en/Stationary RNG.md
+++ b/guides/usum/en/Stationary RNG.md
@@ -9,9 +9,9 @@
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.
 
-If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://pokemonrng.com/guides/sm/en/mysterygift.md) instead.
+If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://pokemonrng.com/guides/usum/en/Mystery%20Gift%20(Event)%20RNG.md) instead.
 
-If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/stationary%20wormhole.md) instead.
+If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG.md) instead.
 
 ## Stationary Pokemon
   - Tapus: Tapu Koko, Tapu Lele, Tapu Bulu, Tapu Fini
@@ -56,7 +56,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 
 ## Step 2 (with NPCs): Create a Timeline
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) to create a timeline and find a target frame.
 
 ## Step 3: Obtaining the wanted Pokemon
 

--- a/guides/usum/en/Stationary Wormhole RNG.md
+++ b/guides/usum/en/Stationary Wormhole RNG.md
@@ -9,7 +9,7 @@ _Get your own perfect Legendary Pokemon!_
 - [PCalc-usum](https://pokemonrng.com/downloads/pcalc/usum)
 
 ### Recommended reading/references
-- [Timeline Guide](https://pokemonrng.com/guides/sm/en/timeline.md)
+- [Timeline Guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md)
 - [Timeline and Timeline 2.0 Guide by](https://github.com/wwwwwwzx/3DSRNGTool/wiki/Gen7-Timeline-Calibration-%28PokeCalcNTR-Only%29) /u/wwwwwwzx as we will be referencing concepts explained in this guide.
 - [3DSRNGTool README](https://github.com/wwwwwwzx/3DSRNGTool/blob/master/README.md) - list of final screens before the Pokemon is generated
 

--- a/guides/usum/en/Wild RNG.md
+++ b/guides/usum/en/Wild RNG.md
@@ -51,7 +51,7 @@ In the Gen 7 games each NPC has an affect on the RNG frames. This is why the fra
 Note: If you are in an area with 0 NPCs, there will not be a "Safe F Only" option. Do not check the "Blink F Only" box. Skip to the 0 NPC section instead. If there are NPCs, make sure to follow the rest of this section.
 ```
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/sm/en/timeline.md) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) to create a timeline and find a target frame.
     - Before making the timeline, open the in game menu with `X` and have the cursor hover over the bag.
 
 ## Step 3: Obtaining the wanted Pokemon


### PR DESCRIPTION
# Guide Details

## I want to (select one)

- [ ] Add a guide
- [x] Modify several existing guides

## Games affected

RSE, SM and USUM

## Type of RNG

Live battery id abuse for RSE, everything except MM/SC egg rng abuse, timeline and timeline leap for SM and SUM

## Language

English

## Notes

This fixes most - if not all - links redirecting to another guide, which were broken due to changes to the files' names.
As it is rn, for example, every guide referring to the timeline guide would link to https://pokemonrng.com/guides/sm/en/timeline.md, which doesn't exist anymore.