### PR TITLE
Updates tools for consistency

### DIFF
--- a/guides/oras/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/oras/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -8,6 +8,8 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc for Gen 6
   - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)

--- a/guides/oras/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/oras/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -8,6 +8,8 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc for Gen 6
   - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)

--- a/guides/sm/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/sm/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -10,9 +10,9 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - A 3DS with CFW (Custom Firmware) (Optional)
    - https://3ds.hacks.guide/ has instructions for installing CFW
-- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc (Optional)
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/sm/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/sm/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -10,11 +10,12 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware) (Optional)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc (Optional)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
+  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/sm/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/sm/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -10,8 +10,9 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/sm/en/Finding Initial Seed with Clocks (no Custom Firmware RNG).md
+++ b/guides/sm/en/Finding Initial Seed with Clocks (no Custom Firmware RNG).md
@@ -7,7 +7,6 @@ _This guide allows you to find your initial seed without using Custom Firmware_
 - Video camera (your phone's camera should do)
   - Optional but it is very handy.
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 
 ## General principle
 

--- a/guides/sm/en/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/sm/en/How to Find Egg Seeds Without Custom Firmware.md
@@ -9,7 +9,6 @@ Note: This guide is for those who do not have access to CFW or homebrew. If you 
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 
 There are two ways of finding the egg seeds. If you have never collected or rejected an egg at the nursery then you can do the 8 Magikarp method. The Eevee gift egg does not count. Otherwise, the only other way is the 127 Magikarp method.
 

--- a/guides/sm/en/Island Scan RNG.md
+++ b/guides/sm/en/Island Scan RNG.md
@@ -4,14 +4,15 @@ _Easy shinies in apricorn balls_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
-- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
-  - [List of Island Scan islands and days for USUM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20USUM.md)
+  - [List of Island Scan islands and days for SM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20SM.md)
 
 ```
 Note: You can get the "honey" item in any store after clearing three trials.

--- a/guides/sm/en/Mystery Gift (Event) RNG.md
+++ b/guides/sm/en/Mystery Gift (Event) RNG.md
@@ -4,8 +4,9 @@ _RNG your events to have 6 IVs_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/sm/en/RNGing Without Custom Firmware.md
+++ b/guides/sm/en/RNGing Without Custom Firmware.md
@@ -5,7 +5,6 @@ _Get your perfect Pokemon without custom firmware_
 ## Tools
 
 - Calculator: [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - Timer: Any two-stage timer
   - [EonTimer 1.6](https://www.dropbox.com/s/tqf13ht2f4bxt66/EonTimer-1_6.zip?dl=0#download)
   - [Emtimer](https://emtimer.mizdra.net/SimpleTimer)
@@ -73,7 +72,7 @@ In summary, the total time span in seconds = (Pre-Timer + Lag) / 1000 + (Target 
 
 ## Step 5: Find initial seed via continue screen clock needles
 
-1. Check [here](<https://pokemonrng.com/guides/tools/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md>)
+1. Check [here](<https://pokemonrng.com/guides/sm/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md>)
 2. Once you get only one seed result, the tool will update it to main window. The starting frame in Time Calculator is updated as well. (417/477 + the number of frames you saw for clocks)
 3. Be sure to double check your seed, most of failures are from the wrong seed ;)
 4. Do not enter your save yet.

--- a/guides/sm/en/Stationary RNG.md
+++ b/guides/sm/en/Stationary RNG.md
@@ -4,10 +4,13 @@ _RNG the overworld Pokemon to have 6 IVs_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+
 
 ### Recomended reading
 

--- a/guides/sm/en/Timeline Guide.md
+++ b/guides/sm/en/Timeline Guide.md
@@ -4,11 +4,13 @@ _The most needed skill to do Gen 7 RNG with custom firmware_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.
 

--- a/guides/sm/en/Timeline Leap Guide.md
+++ b/guides/sm/en/Timeline Leap Guide.md
@@ -2,6 +2,15 @@
 
 _A timeline can predict Pokemon a player can obtain - Timeline leap allows a player to 'leap' onto specific timelines_
 
+## Tools
+
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
+- PCalc
+  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
+  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+
 ## Step 1: Find your target frame
 
 1. In "Filters" set it to search for the Pokemon you are wanting.

--- a/guides/sm/en/Wild RNG.md
+++ b/guides/sm/en/Wild RNG.md
@@ -4,8 +4,9 @@ _For those times when egg RNG is too boring for you_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/tools/en/How to Extract GBA Bios.md
+++ b/guides/tools/en/How to Extract GBA Bios.md
@@ -6,11 +6,12 @@ Some games need a GBA BIOS file to be able to load on emulators. If you are enco
 
 ## Tools
 
-- Either a 3DS with CFW (Custom Firmware)
+- Either a 3DS with CFW (Custom Firmware) and at least 1 VC game from eShop (GB, GBC or NES)
    - https://3ds.hacks.guide/ has instructions for installing CFW
 
 - Or a hacked Wii with a GBA to GameCube Link Cable, and a GameBoy Advance or GameBoy Advance SP
-   - https://wii.guide/ has instructions for hacking a Wii
+   - https://sites.google.com/site/completesg/ has instructions for hacking a Wii
+   - For windows users, you can find an easy to use tool for Wii hacking at https://gbatemp.net/threads/setmiiup-from-stock-to-latest-softmod-in-less-then-5-10-minutes.459416/
 
 ## Using a NES/GB/GBC VC game with a CFW 3DS
 

--- a/guides/tools/en/How to Extract GBA Bios.md
+++ b/guides/tools/en/How to Extract GBA Bios.md
@@ -6,8 +6,11 @@ Some games need a GBA BIOS file to be able to load on emulators. If you are enco
 
 ## Tools
 
-- A CFW 3DS or...
-- A hacked Wii with a GBA to GameCube Link Cable, and a GameBoy Advance or GameBoy Advance SP.
+- Either a 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+
+- Or a hacked Wii with a GBA to GameCube Link Cable, and a GameBoy Advance or GameBoy Advance SP
+   - https://wii.guide/ has instructions for hacking a Wii
 
 ## Using a NES/GB/GBC VC game with a CFW 3DS
 
@@ -26,8 +29,6 @@ Some games need a GBA BIOS file to be able to load on emulators. If you are enco
 
 ## Using a hacked Wii
 
-- For hacking your Wii refer to the following guide: https://wii.guide/
-   
 1. Download the latest [GBA Link Cable Dumper](https://github.com/FIX94/gba-link-cable-dumper/releases).
    - Unzip the folder into the `apps` folder on the console's SD card.
    - Afterwards you should have `apps/gba-gc-link-dumper/boot.dol`.

--- a/guides/tools/en/How to Install PCalc.md
+++ b/guides/tools/en/How to Install PCalc.md
@@ -2,6 +2,11 @@
 
 _Installing a tool to help RNG your Pokemon_
 
+## Tools
+
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+
 ## Step 1: Installing NTR
 
 The first step is to install NTR, do this by installing [BootNTR Selector](https://github.com/Nanquitas/BootNTR/releases).

--- a/guides/tools/en/Using IPS Patches with Luma and Citra.md
+++ b/guides/tools/en/Using IPS Patches with Luma and Citra.md
@@ -4,10 +4,12 @@ _Use game patches for instant text, no outlines, and extra fun_
 
 ## Using IPS files with Luma
 
-1. Find your game's title ID [using 3dsdb](http://www.3dsdb.com/)
-2. Put your code.ips patch at `/luma/titles/<first half of title ID>/<second half of title ID>/code.ips`
+You will need Luma3DS installed on your 3DS for this. Instructions to install Luma3D can be found here : https://3ds.hacks.guide/
 
-For example, Ultra Moon would be `/luma/title/00040000/001B5100/code.ips`
+1. Find your game's title ID [using 3dsdb](http://www.3dsdb.com/)
+2. Put your code.ips patch at `/luma/titles/<title ID>/code.ips`
+
+For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 
 ## Using IPS files with Citra
 

--- a/guides/usum/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/usum/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -10,9 +10,9 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - A 3DS with CFW (Custom Firmware) (Optional)
    - https://3ds.hacks.guide/ has instructions for installing CFW
-- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc (Optional)
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/usum/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/usum/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -10,11 +10,12 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware) (Optional)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc (Optional)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
+  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/usum/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/usum/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -10,8 +10,9 @@ Without Shiny Charm or Masuda Method, PIDs are not generated until the egg is pi
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/usum/en/Finding Initial Seed with Clocks (no Custom Firmware RNG).md
+++ b/guides/usum/en/Finding Initial Seed with Clocks (no Custom Firmware RNG).md
@@ -1,0 +1,62 @@
+# Finding your initial seed in Gen 7 with clocks
+
+_This guide allows you to find your initial seed without using Custom Firmware_
+
+## Tools
+
+- Video camera (your phone's camera should do)
+  - Optional but it is very handy.
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
+
+## General principle
+
+Each time you boot up your game, an `initial seed` (also called `seed` throughout this guide) is created. This seed can then be used to RNG abuse wild encounters, events, in-game gifts, etc.
+
+At the "Continue" screen of the game, before your character picture loads, you can see a clock. Thanks to the clock needles position, we are going to be able to find our initial seed. The idea is to check a certain number of clocks (between 8 and 10), without restarting the game, in order to get the seed value.
+
+Since each seed is generated when you launch the game, checking the clocks needs to be done without restarting the game. You can simply leave the "Continue" screen by pressing **B**.
+
+![](https://i.imgur.com/2Nh45HB.gif)
+
+## Step 1: Setup 3DSRNGTool
+
+1. Open the 3DSRNGTool you downloaded.
+2. Select your game version on the top right. ("Sun", "Moon", "Ultra Sun" or "Ultra Moon").
+3. Go to "Tools" > "Gen 7 Main RNG Tool". It looks like the following picture.
+   ![](https://i.imgur.com/YZiTi7s.png)
+4. Make sure that in the `InputBox` you have the option `End Position` selected with the number `4`.
+5. Select the `Find Initial Seed via clock hands` option as well.
+
+## Step 2: Recording the clock needles
+
+1. Boot your 3DS and open the game. Leave it on the "Press Start" screen.
+
+   - You can leave the animations playing, they do not influence the seed (or the frames).
+
+2. Start recording your 3DS with your camera.
+3. Press **A** or **Start** to go into the "Continue" screen.
+
+   - Make sure you recorded the whole clock movement: from the moment you enter the "Continue" screen, until your character picture is displayed.
+
+4. Press **B** to go back to the "Press Start" screen.
+5. Repeat this process of alternating between the "Press Start" and the "Continue" screen until you get 10 clock movements.
+
+## Step 3: Finding the seed
+
+Once you have recorded the 10 clock movements we need to list them in the tool to get the initial seed.
+
+1. In the `InputBox` select the clock that corresponds to the final position of each clock.
+
+   - This End Position occurs right before the picture loads.
+   - The End Position of the gif showed at the beginning is last option of the Gen7 Main RNG Tool.
+   - You will see a number appear in the `Needle List` of the tool (12 for the gif demo).
+
+2. The tool will try to find your seed after you have input 8 Needle positions.
+   ![](https://i.imgur.com/X4Tekx5.png)
+
+- Sometimes you will get various results with only 8 Needles, that is why we checked 10 clocks. Enter the remaining 2 until you see a single seed.
+  - The last 2 Needle positions are also useful to confirm your seed.
+- If you do not have any results try checking your video again and see where you made a mistake on the Needle positions.
+- If you still do not find any results, restart the game and try again recording 10 new clocks.
+
+Your seed should appear in the `Results` field if you did everything correctly.

--- a/guides/usum/en/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/usum/en/How to Find Egg Seeds Without Custom Firmware.md
@@ -9,7 +9,6 @@ Note: This guide is for those who do not have access to CFW or homebrew. If you 
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 
 There are two ways of finding the egg seeds. If you have never collected or rejected an egg at the nursery then you can do the 8 Magikarp method. The Eevee gift egg does not count. Otherwise, the only other way is the 127 Magikarp method.
 

--- a/guides/usum/en/Island Scan.md
+++ b/guides/usum/en/Island Scan.md
@@ -4,11 +4,12 @@ _Easy shinies in apricorn balls_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
-- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
   - [List of Island Scan islands and days for USUM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20USUM.md)

--- a/guides/usum/en/Mystery Gift (Event) RNG.md
+++ b/guides/usum/en/Mystery Gift (Event) RNG.md
@@ -4,8 +4,9 @@ _RNG your events to have 6 IVs_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/usum/en/RNGing Without Custom Firmware.md
+++ b/guides/usum/en/RNGing Without Custom Firmware.md
@@ -5,7 +5,6 @@ _Get your perfect Pokemon without custom firmware_
 ## Tools
 
 - Calculator: [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - Timer: Any two-stage timer
   - [EonTimer 1.6](https://www.dropbox.com/s/tqf13ht2f4bxt66/EonTimer-1_6.zip?dl=0#download)
   - [Emtimer](https://emtimer.mizdra.net/SimpleTimer)
@@ -73,7 +72,7 @@ In summary, the total time span in seconds = (Pre-Timer + Lag) / 1000 + (Target 
 
 ## Step 5: Find initial seed via continue screen clock needles
 
-1. Check [here](<https://pokemonrng.com/guides/tools/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md>)
+1. Check [here](<https://pokemonrng.com/guides/usum/en/Finding%20Initial%20Seed%20with%20Clocks%20(no%20Custom%20Firmware%20RNG).md>)
 2. Once you get only one seed result, the tool will update it to main window. The starting frame in Time Calculator is updated as well. (417/477 + the number of frames you saw for clocks)
 3. Be sure to double check your seed, most of failures are from the wrong seed ;)
 4. Do not enter your save yet.

--- a/guides/usum/en/SOS RNG Guide.md
+++ b/guides/usum/en/SOS RNG Guide.md
@@ -9,7 +9,6 @@ _One of the most challenging Gen 7 RNGs with fun rewards_
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Recommended reading/references
 

--- a/guides/usum/en/SOS RNG Guide.md
+++ b/guides/usum/en/SOS RNG Guide.md
@@ -4,12 +4,12 @@ _One of the most challenging Gen 7 RNGs with fun rewards_
 
 ## Tools
 
-- Console with CFW
-- [3DSRNGTool](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts)
-  - [Github link](https://github.com/wwwwwwzx/3DSRNGTool)
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Guide for installing PCalc](https://pokemonrng.com/guides/tools/en/How%20to%20Install%20PCalc.md)
+  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Recommended reading/references
 

--- a/guides/usum/en/Stationary RNG.md
+++ b/guides/usum/en/Stationary RNG.md
@@ -4,6 +4,8 @@ _RNG the overworld Pokemon to have 6 IVs_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)

--- a/guides/usum/en/Stationary Wormhole RNG.md
+++ b/guides/usum/en/Stationary Wormhole RNG.md
@@ -4,8 +4,11 @@ _Get your own perfect Legendary Pokemon!_
 
 ## Tools
 
-- [3DSRNGTool](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts) - Github link: https://github.com/wwwwwwzx/3DSRNGTool
-- [PCalc-usum](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
+- PCalc
+  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 
 ### Recommended reading/references
 

--- a/guides/usum/en/Timeline Guide.md
+++ b/guides/usum/en/Timeline Guide.md
@@ -4,8 +4,9 @@ _The most needed skill to do Gen 7 RNG with custom firmware_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/usum/en/Timeline Leap Guide.md
+++ b/guides/usum/en/Timeline Leap Guide.md
@@ -2,6 +2,15 @@
 
 _A timeline can predict Pokemon a player can obtain - Timeline leap allows a player to 'leap' onto specific timelines_
 
+## Tools
+
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
+- [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
+- PCalc
+  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
+  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+
 ## Step 1: Find your target frame
 
 1. In "Filters" set it to search for the Pokemon you are wanting.

--- a/guides/usum/en/Wild RNG.md
+++ b/guides/usum/en/Wild RNG.md
@@ -4,8 +4,9 @@ _For those times when egg RNG is too boring for you_
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc
   - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)

--- a/guides/xy/en/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/xy/en/Egg RNG With Masuda Method or Shiny Charm.md
@@ -8,6 +8,8 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - PCalc for Gen 6
   - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)

--- a/guides/xy/en/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/xy/en/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -8,8 +8,9 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
+- A 3DS with CFW (Custom Firmware)
+   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts).
 - PCalc for Gen 6
   - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
   - [PCalc-xy](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)


### PR DESCRIPTION
# Guide Details

## I want to (select one)

- [ ] Add a guide
- [x] Modify several existing guides

## Games affected

- XY
- ORAS
- SM
- USUM

## Type of RNG

All

## Language

English

## Notes

Updates tools section of several guides to:
- Mention CFW and how to get it
- Remove the now deprecated link to 3DSRNGTool's Appveyor
Also moves the 'Finding Initial Seed with Clocks (no CFW)' guide to SM
and USUM folders, instead of the Tools folder.
And other minors fixes
