### PR TITLE
Fixing Broken Links

### DIFF
--- a/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -113,6 +113,6 @@ You can choose any of the given frames, but lower frames are generally better du
   - Ask someone else to find it for you. /r/SVEXchange is one place this can be done.
 
 - If you are not using PCalc and do not know your egg seeds there are methods to find them.
-  - If you have already used the daycare by having accepted or rejected eggs, and do not wish to use Homebrew or CFW, then you will have to do the [127 Magikarp method](https://pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/) to find your egg seeds.
-  - If you have not used the daycare and do not wish to use Homebrew or CFW, you can use the [8 egg method](https://pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/) to find your egg seeds.
+  - If you have already used the daycare by having accepted or rejected eggs, and do not wish to use Homebrew or CFW, then you will have to do the [127 Magikarp method](https://www.pokemonrng.com/retail-sm-egg-seed-no-cfw) to find your egg seeds.
+  - If you have not used the daycare and do not wish to use Homebrew or CFW, you can use the [8 egg method](https://www.pokemonrng.com/retail-sm-egg-seed-no-cfw) to find your egg seeds.
   - If you have access to Homebrew or CFW you can use PKHeX to view your egg seeds after using a save manager such as Checkpoint to extract the save file.

--- a/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -109,7 +109,7 @@ With PCalc you can check which egg frame you are on by looking at your egg seeds
 
    - Check the "Main RNG Egg (PID)" box in 3DSRNGTool under "Current Status".
    - Afterward, reset "Filters" by clicking on the gear icon.
-   - Then follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) to create a timeline.
+   - Then follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline.
    - Creating a timeline is necessary to know what frames you can actually land on due to NPC influence on frames.
 
 5. After making a timeline you can now search for a target frame that you are able to land on.

--- a/guides/Sun and Moon/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/Sun and Moon/How to Find Egg Seeds Without Custom Firmware.md
@@ -69,7 +69,7 @@ The gift Eevee egg from the nursery does not count!
    - If the nature does not match, then your egg seeds were not correct. You will have to redo the 127 eggs again to get correct egg seeds.
    - You can right click on the frame that matched and choose "Set as Current Status" to update the "Current Status" with your egg seeds.
 
-8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/).
+8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://www.pokemonrng.com/retail-sm-egg-mmsc).
 
 ## Step 1: Setup for 8 Egg Method
 
@@ -105,4 +105,4 @@ The gift Eevee egg does not count!
 
    - If they do not match then you will have to redo the 8 eggs again. Double check that the correct natures are entered in the order you accepted the eggs.
 
-5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/).
+5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://www.pokemonrng.com/retail-sm-egg-mmsc).

--- a/guides/Sun and Moon/Island Scan RNG.md
+++ b/guides/Sun and Moon/Island Scan RNG.md
@@ -15,7 +15,7 @@ subCategory: 'Custom Firmware'
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
-  - [List of Island Scan islands and days for SM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20SM/)
+  - [List of Island Scan islands and days for SM](https://www.pokemonrng.com/misc-3ds-island-scan-sm)
 
 ```
 Note: You can get the "honey" item in any store after clearing three trials.
@@ -52,7 +52,7 @@ Note: You can find your TSV in PCalc in the Game Info window. Press "Start + Up"
 
 ### On the right of 3DSRNGTool
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
+1. Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
 2. You should now have a target frame you wish to hit.
 
 ### In the middle of 3DSRNGTool

--- a/guides/Sun and Moon/Mystery Gift.md
+++ b/guides/Sun and Moon/Mystery Gift.md
@@ -47,7 +47,7 @@ Note: With some events, the game will trigger a Pokedex registration animation (
 
 ## Step 3: RNGing the Pokemon
 
-1. Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/)
+1. Create a timeline following this guide: [Gen 7 Timeline Guide](https://www.pokemonrng.com/retail-usum-timeline)
 
 2. Advance to your target frame and when you land on it, press A to unpause the game and obtain the Pokemon.
 

--- a/guides/Sun and Moon/Stationary RNG.md
+++ b/guides/Sun and Moon/Stationary RNG.md
@@ -18,7 +18,7 @@ subCategory: 'Custom Firmware'
 
 If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://www.pokemonrng.com/retail-sm-myster-gift) instead.
 
-If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG/) instead.
+If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://www.pokemonrng.com/retail-usum-wormhole) instead.
 
 ## Final Screens
 
@@ -50,7 +50,7 @@ The gift Eevee egg and the move Pikachu gift are exceptions. Synchronize has no 
 
 ## Step 2 (with NPCs): Create a Timeline
 
-Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) to create a timeline and find a target frame.
+Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline and find a target frame.
 
 ## Step 3: Obtaining the wanted Pokemon
 

--- a/guides/Sun and Moon/Wild RNG.md
+++ b/guides/Sun and Moon/Wild RNG.md
@@ -50,7 +50,8 @@ Note: For wild Pokemon, Synchronize has a 50% chance of having the Pokemon you e
 Note: If you are in an area with 0 NPCs, there will not be a "Safe F Only" option. Do not check the "Blink F Only" box. Skip to the 0 NPC section instead. If there are NPCs, make sure to follow the rest of this section.
 ```
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline
+) to create a timeline and find a target frame.
    - Before making the timeline, open the in game menu with `X` and have the cursor hover over the bag.
 
 ## Step 3: Obtaining the wanted Pokemon

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -113,6 +113,6 @@ You can choose any of the given frames, but lower frames are generally better du
   - Ask someone else to find it for you. /r/SVEXchange is one place this can be done.
 
 - If you are not using PCalc and do not know your egg seeds there are methods to find them.
-  - If you have already used the daycare by having accepted or rejected eggs, and do not wish to use Homebrew or CFW, then you will have to do the [127 Magikarp method](https://pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/) to find your egg seeds.
-  - If you have not used the daycare and do not wish to use Homebrew or CFW, you can use the [8 egg method](https://pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/) to find your egg seeds.
+  - If you have already used the daycare by having accepted or rejected eggs, and do not wish to use Homebrew or CFW, then you will have to do the [127 Magikarp method](https://www.pokemonrng.com/retail-usum-egg-seed-no-cfw) to find your egg seeds.
+  - If you have not used the daycare and do not wish to use Homebrew or CFW, you can use the [8 egg method](https://www.pokemonrng.com/retail-usum-egg-seed-no-cfw) to find your egg seeds.
   - If you have access to Homebrew or CFW you can use PKHeX to view your egg seeds after using a save manager such as Checkpoint to extract the save file.

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -109,7 +109,7 @@ With PCalc you can check which egg frame you are on by looking at your egg seeds
 
    - Check the "Main RNG Egg (PID)" box in 3DSRNGTool under "Current Status".
    - Afterward, reset "Filters" by clicking on the gear icon.
-   - Then follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md) to create a timeline.
+   - Then follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline.
    - Creating a timeline is necessary to know what frames you can actually land on due to NPC influence on frames.
 
 5. After making a timeline you can now search for a target frame that you are able to land on.

--- a/guides/Ultra Sun and Ultra Moon/How to Find Egg Seeds Without Custom Firmware.md
+++ b/guides/Ultra Sun and Ultra Moon/How to Find Egg Seeds Without Custom Firmware.md
@@ -69,7 +69,7 @@ The gift Eevee egg from the nursery does not count!
    - If the nature does not match, then your egg seeds were not correct. You will have to redo the 127 eggs again to get correct egg seeds.
    - You can right click on the frame that matched and choose "Set as Current Status" to update the "Current Status" with your egg seeds.
 
-8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/).
+8. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://www.pokemonrng.com/retail-usum-egg-mmsc).
 
 ## Step 1: Setup for 8 Egg Method
 
@@ -105,4 +105,4 @@ The gift Eevee egg does not count!
 
    - If they do not match then you will have to redo the 8 eggs again. Double check that the correct natures are entered in the order you accepted the eggs.
 
-5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/).
+5. Soft reset and you can then egg RNG following the [Masuda Method/Shiny Charm Egg RNG Guide](https://www.pokemonrng.com/retail-usum-egg-mmsc).

--- a/guides/Ultra Sun and Ultra Moon/Island Scan.md
+++ b/guides/Ultra Sun and Ultra Moon/Island Scan.md
@@ -15,7 +15,7 @@ subCategory: 'Custom Firmware'
   - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
-  - [List of Island Scan islands and days for USUM](https://pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20USUM/)
+  - [List of Island Scan islands and days for USUM](https://www.pokemonrng.com/misc-3ds-island-scan-usum)
 
 ```
 Note: You can get the "honey" item in any store after clearing three trials.
@@ -52,7 +52,7 @@ Note: You can find your TSV in PCalc in the Game Info window. Press "Start + Up"
 
 ### On the right of 3DSRNGTool
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
+1. Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) using the `NPC Count` PCalc shows for the number of NPCs. Wait at least 30 seconds after bringing up the window to allow for the NPC counter to calibrate correctly.
 2. You should now have a target frame you wish to hit.
 
 ### In the middle of 3DSRNGTool

--- a/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
+++ b/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
@@ -47,7 +47,7 @@ Note: With some events, the game will trigger a Pokedex registration animation (
 
 ## Step 3: RNGing the Pokemon
 
-1. Create a timeline following this guide: [Gen 7 Timeline Guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/)
+1. Create a timeline following this guide: [Gen 7 Timeline Guide](https://www.pokemonrng.com/retail-usum-timeline)
 
 2. Advance to your target frame and when you land on it, press A to unpause the game and obtain the Pokemon.
 

--- a/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
@@ -57,7 +57,7 @@ Note: It is recommended to set up for the SOS chaining first before starting the
 
 1. You can either wander around until you find the correct Pokemon to SOS or you can RNG it.
 
-   - A guide to Gen 7 wild RNG can be found [here](https://pokemonrng.com/guides/usum/en/Wild%20RNG/).
+   - A guide to Gen 7 wild RNG can be found [here](https://www.pokemonrng.com/retail-usum-wild).
 
 2. Once in the encounter open the "Tools" menu on 3DSRNGTool and select "Misc. RNG Tool". Switch the RNG type to "G7 SFMT (32bit)" and choose the "SOS" tab.
 

--- a/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
@@ -18,7 +18,7 @@ subCategory: 'Custom Firmware'
 
 If you are wanting to RNG a Mystery Gift (or Event) Pokemon instead, follow the [Gen 7 Mystery Gift RNG guide](https://www.pokemonrng.com/retail-usum-mystery-gift) instead.
 
-If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG/) instead.
+If you are wanting to RNG a Pokemon in a Wormhole, follow the [USUM Wormhole RNG guide](https://www.pokemonrng.com/retail-usum-wormhole) instead.
 
 ## Final Screens
 
@@ -50,7 +50,7 @@ The gift Eevee egg and the move Pikachu gift are exceptions. Synchronize has no 
 
 ## Step 2 (with NPCs): Create a Timeline
 
-Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) to create a timeline and find a target frame.
+Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline and find a target frame.
 
 ## Step 3: Obtaining the wanted Pokemon
 

--- a/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
@@ -15,7 +15,7 @@ subCategory: 'Custom Firmware'
 
 ### Recommended reading/references
 
-- [Timeline Guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/)
+- [Timeline Guide](https://www.pokemonrng.com/retail-usum-timeline)
 - [Timeline and Timeline 2.0 Guide](https://github.com/wwwwwwzx/3DSRNGTool/wiki/Gen7-Timeline-Calibration-%28PokeCalcNTR-Only%29)
 - [3DSRNGTool README](https://github.com/wwwwwwzx/3DSRNGTool/blob/master/README.md) - list of final screens before the Pokemon is generated
 
@@ -27,7 +27,7 @@ The seed is shown at the top of the overlay with the label of "Init Seed:". In t
 
 ## Step 2: Calibrating a basic timeline
 
-Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) to create a timeline and find a target frame.
+Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline and find a target frame.
 
 ## Step 3: Timeline 2.0
 

--- a/guides/Ultra Sun and Ultra Moon/Wild RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Wild RNG.md
@@ -50,7 +50,7 @@ Note: For wild Pokemon, Synchronize has a 50% chance of having the Pokemon you e
 Note: If you are in an area with 0 NPCs, there will not be a "Safe F Only" option. Do not check the "Blink F Only" box. Skip to the 0 NPC section instead. If there are NPCs, make sure to follow the rest of this section.
 ```
 
-1. Follow the [timeline guide](https://pokemonrng.com/guides/usum/en/Timeline%20Guide/) to create a timeline and find a target frame.
+1. Follow the [timeline guide](https://www.pokemonrng.com/retail-usum-timeline) to create a timeline and find a target frame.
    - Before making the timeline, open the in game menu with `X` and have the cursor hover over the bag.
 
 ## Step 3: Obtaining the wanted Pokemon

--- a/guides/XY/XY Trainer ID, Secret ID, and TSV RNG Guide.md
+++ b/guides/XY/XY Trainer ID, Secret ID, and TSV RNG Guide.md
@@ -16,7 +16,7 @@ Make sure to back up your save file using a save file manager such as [Checkpoin
 - A 3DS with CFW (Custom Firmware)
   - https://3ds.hacks.guide/ has instructions for installing CFW
 - [PCalc for X/Y](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
-  - [Here](https://pokemonrng.com/guides/tools/en/How%20to%20Install%20PCalc.md) is a guide on how to install PCalc
+  - [Here](https://www.pokemonrng.com/misc-3ds-installing-pcalc) is a guide on how to install PCalc
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - (Optional) A network connection
 


### PR DESCRIPTION
Hi, I went through the guides and replaced all the broken links I could find. These are the links which I changed: 

- Mystery Gift USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Egg RNG With MM/SC SUMO: pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/ to www.pokemonrng.com/retail-sm-egg-seed-no-cfw

- Egg RNG Without MM/SC SUMO: https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md to www.pokemonrng.com/retail-usum-timeline

- Find Seeds without CFW SUMO: pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/ to www.pokemonrng.com/retail-sm-egg-mmsc

- Island Scan RNG SUMO: pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20SM/ to www.pokemonrng.com/misc-3ds-island-scan-sm

- Island Scan RNG SUMO: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Mystery Gift SUMO: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Stationary RNG SUMO: pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG/ to www.pokemonrng.com/retail-usum-wormhole

- Stationary RNG SUMO: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Wild RNG: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Egg RNG With MM/SC USUM: pokemonrng.com/guides/usum/en/How%20to%20Find%20Egg%20Seeds%20Without%20Custom%20Firmware/ to www.pokemonrng.com/retail-sm-egg-seed-no-cfw

- Egg RNG Without MM/SC USUM: https://pokemonrng.com/guides/usum/en/Timeline%20Guide.md to www.pokemonrng.com/retail-usum-timeline

- Find Seeds without CFW USUM: pokemonrng.com/guides/usum/en/Egg%20RNG%20With%20Masuda%20Method%20or%20Shiny%20Charm/ to www.pokemonrng.com/retail-sm-egg-mmsc

- Island Scan USUM: pokemonrng.com/guides/tools/en/Island%20Scan%20Pokemon%20-%20USUM/ to www.pokemonrng.com/misc-3ds-island-scan-usum

- Island Scan USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Mystery Gift USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- SOS RNG USUM: pokemonrng.com/guides/usum/en/Wild%20RNG/ to www.pokemonrng.com/retail-usum-wild

- Stationary USUM: pokemonrng.com/guides/usum/en/Stationary%20Wormhole%20RNG/ to www.pokemonrng.com/retail-usum-wormhole

- Stationary USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Wormhole USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- Wild RNG USUM: pokemonrng.com/guides/usum/en/Timeline%20Guide/ to www.pokemonrng.com/retail-usum-timeline

- XY ID/SID/TSV: pokemonrng.com/guides/tools/en/How%20to%20Install%20PCalc.md to www.pokemonrng.com/misc-3ds-installing-pcalc