### PR TITLE
Rename Emerald Egg Guide

### DIFF
--- a/guides/Emerald/Egg RNG.md
+++ b/guides/Emerald/Egg RNG.md
@@ -1,6 +1,6 @@
 ---
-title: 'Emerald Egg RNG'
-description: 'RNG Eggs in Emerald'
+title: 'Egg RNG'
+description: 'Guide for RNGing Eggs from the Daycare'
 slug: 'emulator-emerald-egg'
 subCategory: 'Emulator'
 ---

--- a/guides/Emerald/Egg RNG.md
+++ b/guides/Emerald/Egg RNG.md
@@ -1,6 +1,6 @@
 ---
 title: 'Egg RNG'
-description: 'Guide for RNGing Eggs from the Daycare'
+description: 'RNG Eggs from the Daycare'
 slug: 'emulator-emerald-egg'
 subCategory: 'Emulator'
 ---


### PR DESCRIPTION
Since Emerald was moved to its own category, having Emerald in the guide name is now redundant.