### PR TITLE
Edit Ruby & Sapphire Guides

### DIFF
--- a/guides/Ruby and Sapphire/Dead Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Dead Battery TID RNG.md
@@ -1,6 +1,6 @@
 ---
-title: 'Dead Battery TID RNG'
-description: 'Get that special TID/SID combo'
+title: 'Dead Battery TID/SID RNG'
+description: 'RNG for a specific TID/SID combination with less options by not changing the date and time'
 slug: 'emulator-rs-dead-battery-tid'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Dead Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Dead Battery TID RNG.md
@@ -1,6 +1,6 @@
 ---
 title: 'Dead Battery TID/SID RNG'
-description: 'RNG for a specific TID/SID combination with less options by not changing the date and time'
+description: 'RNG for a specific TID/SID combination with less options than live battery'
 slug: 'emulator-rs-dead-battery-tid'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Dead Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Dead Battery TID RNG.md
@@ -1,7 +1,7 @@
 ---
 title: 'Dead Battery TID RNG'
 description: 'Get that special TID/SID combo'
-slug: 'emulator-rse-dead-battery-tid'
+slug: 'emulator-rs-dead-battery-tid'
 subCategory: 'Emulator'
 ---
 

--- a/guides/Ruby and Sapphire/Egg RNG.md
+++ b/guides/Ruby and Sapphire/Egg RNG.md
@@ -1,6 +1,6 @@
 ---
 title: 'Egg RNG'
-description: 'RNG Eggs from the daycare'
+description: 'RNG Eggs from the Daycare'
 slug: 'emulator-rs-egg'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Egg RNG.md
+++ b/guides/Ruby and Sapphire/Egg RNG.md
@@ -1,6 +1,6 @@
 ---
-title: 'Ruby/Sapphire Egg RNG'
-description: 'RNG Eggs in Ruby/Sapphire'
+title: 'Egg RNG'
+description: 'RNG Eggs from the daycare'
 slug: 'emulator-rs-egg'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Live Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Live Battery TID RNG.md
@@ -1,6 +1,6 @@
 ---
 title: 'Live Battery TID/SID RNG'
-description: 'RNG for a specific TID/SID combination with more options by changing the date and time'
+description: 'RNG for a specific TID/SID combination with more options than dead battery'
 slug: 'emulator-rs-live-battery-tid'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Live Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Live Battery TID RNG.md
@@ -1,6 +1,6 @@
 ---
-title: 'Live battery TID Abuse'
-description: 'The harder way to get that special TID/SID combo with more options'
+title: 'Live Battery TID/SID RNG'
+description: 'RNG for a specific TID/SID combination with more options by changing the date and time'
 slug: 'emulator-rs-live-battery-tid'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Live Battery TID RNG.md
+++ b/guides/Ruby and Sapphire/Live Battery TID RNG.md
@@ -1,7 +1,7 @@
 ---
 title: 'Live battery TID Abuse'
 description: 'The harder way to get that special TID/SID combo with more options'
-slug: 'emulator-rse-live-battery-tid'
+slug: 'emulator-rs-live-battery-tid'
 subCategory: 'Emulator'
 ---
 

--- a/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
+++ b/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
@@ -1,6 +1,6 @@
 ---
-title: 'Live Battery Stationary Abuse (Ruby/Sapphire)'
-description: 'Enjoy shiny 6 IV legends from Gen 3'
+title: 'Live Battery Stationary RNG'
+description: 'RNG stationary Pokemon with more options by changing the date and time'
 slug: 'emulator-rs-stationary'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
+++ b/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
@@ -1,7 +1,7 @@
 ---
 title: 'Live Battery Stationary Abuse (Ruby/Sapphire)'
 description: 'Enjoy shiny 6 IV legends from Gen 3'
-slug: 'emulator-rse-stationary'
+slug: 'emulator-rs-stationary'
 subCategory: 'Emulator'
 ---
 

--- a/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
+++ b/guides/Ruby and Sapphire/Ruby & Sapphire Live Battery Stationary Abuse.md
@@ -1,6 +1,6 @@
 ---
 title: 'Live Battery Stationary RNG'
-description: 'RNG stationary Pokemon with more options by changing the date and time'
+description: 'RNG stationary Pokemon with more options than dead battery'
 slug: 'emulator-rs-stationary'
 subCategory: 'Emulator'
 ---

--- a/guides/Ruby and Sapphire/Shiny WISHMKR Jirachi with wishmaker-calc.md
+++ b/guides/Ruby and Sapphire/Shiny WISHMKR Jirachi with wishmaker-calc.md
@@ -1,7 +1,7 @@
 ---
 title: 'How to RNG Shiny WISHMKR Jirachi using wishmaker-calc'
 description: 'Unlimited Shiny Jirachis'
-slug: 'emulator-rse-wishmaker'
+slug: 'emulator-rs-wishmaker'
 subCategory: 'Emulator'
 ---
 

--- a/guides/Ruby and Sapphire/Shiny WISHMKR Jirachi with wishmaker-calc.md
+++ b/guides/Ruby and Sapphire/Shiny WISHMKR Jirachi with wishmaker-calc.md
@@ -1,6 +1,6 @@
 ---
-title: 'How to RNG Shiny WISHMKR Jirachi using wishmaker-calc'
-description: 'Unlimited Shiny Jirachis'
+title: 'Shiny WISHMKR Jirachi RNG using wishmaker-calc'
+description: 'RNG Jirachi from the Colosseum bonus disc'
 slug: 'emulator-rs-wishmaker'
 subCategory: 'Emulator'
 ---


### PR DESCRIPTION
Renamed the guides and changed the guide descriptions to better reflect what each guide is for. Also changed the slugs to be only `rs` instead of `rse`.