### PR TITLE
Update tools for Gen 4 and 5 guides

### DIFF
--- a/guides/Black 2 and White 2/Dream Radar.md
+++ b/guides/Black 2 and White 2/Dream Radar.md
@@ -7,18 +7,11 @@ subCategory: 'Emulator'
 
 ## Tools
 
-- [Latest Build of RNG Reporter](https://ci.appveyor.com/project/Admiral-Fish/rngreporter/build/artifacts)
-- [DeSmuMe Dev Build](https://sourceforge.net/projects/desmume/files/desmume/0.9.11/desmume-0.9.11-win32-dev.zip/download)
-- Lua .dlls
-  - [x86 .dlls](https://www.dropbox.com/s/2o4hdphn7j9z349/lua-dll-x86.zip?dl=0)
-  - [x64 .dlls](https://www.dropbox.com/s/t8yttukleqserzp/lua-dll-x64.rar?dl=0)
-    - If using x64 version of DeSmuMe, download the x64 .dlls. Otherwise, download the x86 .dlls.
-    - Place the .dlls in the same folder as the DeSmuMe executable.
-- Pokemon Black 2 or White 2 .nds files (You can dump the carts yourself using a CFW 3DS with Godmode9)
-- [The Lua Scripts corresponding to your rom's language](http://pokerng.forumcommunity.net/?t=56443955)
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
+- [RNG Reporter](https://github.com/Admiral-Fish/RNGReporter/releases)
 - [Suloku's Gen V Save Tool (Optional)](https://github.com/suloku/BW_tool/releases)
   - Alternatively, you can extract your BW2 save file after obtaining the Pokemon you wish to RNG from the Dream Radar if you rather not inject.
-- [RunAsDate (Optional)](https://runasdate.en.softonic.com/)
 
 ```
 Note: You may have noticed a "Dream Radar" tab in RNG Reporter. During the time of this guide being written, that tab does not work. Therefore, this guide will explain an alternate method of finding seeds and desired IV/Nature combinations.

--- a/guides/Black 2 and White 2/Using Runasdate to RNG Initial Seed.md
+++ b/guides/Black 2 and White 2/Using Runasdate to RNG Initial Seed.md
@@ -11,9 +11,10 @@ Note: This guide assumes that you have found your target seed. It is necessary t
 
 ## Tools
 
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
 - [RunAsDate](https://www.nirsoft.net/utils/run_as_date.html)
   - Take care to choose the right version (32 or 64 bits) for your computer.
-- [Lua Scripts for Gen 5](https://pokerng.forumcommunity.net/?t=56394378)
 
 ### What is RunAsDate?
 

--- a/guides/Black and White/Entralink.md
+++ b/guides/Black and White/Entralink.md
@@ -7,16 +7,11 @@ subCategory: 'Emulator'
 
 ## Tools
 
-- [Latest Build of RNG Reporter](https://ci.appveyor.com/project/Admiral-Fish/rngreporter/build/artifacts)
-- [DeSmuMe dev build](https://sourceforge.net/projects/desmume/files/desmume/0.9.11/desmume-0.9.11-win32-dev.zip/download)
-- The lua .dlls for DeSmuMe
-  - [x86 .dll](https://www.dropbox.com/s/2o4hdphn7j9z349/lua-dll-x86.zip?dl=0)
-  - [x64 .dll](https://www.dropbox.com/s/t8yttukleqserzp/lua-dll-x64.rar?dl=0)
-- Pokemon Black or White (You will need to dump this yourself)
-- [The BW Entralink Scripts for your language](http://pokerng.forumcommunity.net/?t=56443955)
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
+- [RNG Reporter](https://github.com/Admiral-Fish/RNGReporter/releases)
 - A save with access to the C-Gear (And with the profile/calibration set up)
 - [Suloku's Gen V Save Tool (optional)](https://projectpokemon.org/home/forums/topic/37801-gen-5-generation-5-save-tool-entralink-medals-join-avenue-and-others-not-in-pokegen/)
-- [runasdate (optional)](https://runasdate.en.softonic.com/)
 
 ## Step 1: Inject an RNG Target (Optional)
 

--- a/guides/Black and White/Find DS Parameters.md
+++ b/guides/Black and White/Find DS Parameters.md
@@ -7,14 +7,9 @@ subCategory: 'Emulator'
 
 ## Tools
 
-- [Latest Build of RNG Reporter](https://ci.appveyor.com/project/Admiral-Fish/rngreporter/build/artifacts)
-- [DeSmuMe Dev Build](https://sourceforge.net/projects/desmume/files/desmume/0.9.11/desmume-0.9.11-win32-dev.zip/download)
-- Lua .dlls
-  - [x86 .dlls](https://www.dropbox.com/s/2o4hdphn7j9z349/lua-dll-x86.zip?dl=0)
-  - [x64 .dlls](https://www.dropbox.com/s/t8yttukleqserzp/lua-dll-x64.rar?dl=0)
-- Pokemon BW or BW2 .nds files (You can dump the carts yourself using a CFW 3DS with Godmode9)
-- [The Lua Scripts corresponding to your rom's language](http://pokerng.forumcommunity.net/?t=56443955)
-  - Password is `allyouneedisnoob`.
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
+- [RNG Reporter](https://github.com/Admiral-Fish/RNGReporter/releases)
 - [RunAsDate](https://runasdate.en.softonic.com/)
 
 ## Things To Know

--- a/guides/Black and White/Roamers.md
+++ b/guides/Black and White/Roamers.md
@@ -7,15 +7,9 @@ subCategory: 'Emulator'
 
 ## Tools
 
-- RNGReporter
-- Generation 5 Lua Scripts
-- Generation 5 RNG Experience
-- Generation 5 TID/SID
-- DeSmuMe dev build
-- Lua .dlls
-- Pokemon BW
-- runasdate (optional)
-- a few hours
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
+- [RNG Reporter](https://github.com/Admiral-Fish/RNGReporter/releases)
 
 ![](https://i.imgur.com/kDti9qn.png?1)
 

--- a/guides/Black and White/Using Runasdate to RNG Initial Seed.md
+++ b/guides/Black and White/Using Runasdate to RNG Initial Seed.md
@@ -11,9 +11,10 @@ Note: This guide assumes that you have found your target seed. It is necessary t
 
 ## Tools
 
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
 - [RunAsDate](https://www.nirsoft.net/utils/run_as_date.html)
   - Take care to choose the right version (32 or 64 bits) for your computer.
-- [Lua Scripts for Gen 5](https://pokerng.forumcommunity.net/?t=56394378)
 
 ### What is RunAsDate?
 

--- a/guides/Diamond, Pearl, and Platinum/Stationary.md
+++ b/guides/Diamond, Pearl, and Platinum/Stationary.md
@@ -8,9 +8,8 @@ subCategory: 'Emulator'
 ## Tools
 
 - [PokeFinder](https://github.com/Admiral-Fish/PokeFinder/releases)
-- [Desmume](http://desmume.org/download/)
-- [Gen 4 Lua Scripts for your game language](https://pokerng.forumcommunity.net/?t=56443955#entry396434991)
-  - The password for the lua script archive is `allyouneedisnoob`
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
 
 ## Step 1: Finding your Target Frame
 

--- a/guides/Diamond, Pearl, and Platinum/Using Runasdate to RNG Initial Seed.md
+++ b/guides/Diamond, Pearl, and Platinum/Using Runasdate to RNG Initial Seed.md
@@ -11,8 +11,9 @@ Note: Important note: This guide assumes that you have found your Target Seed, a
 
 ## Tools
 
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
 - [RunAsDate](https://www.nirsoft.net/utils/run_as_date.html) : Take care to choose the right version (32 or 64 bits) for your computer.
-- [Lua Scripts for Gen 4](http://pokerng.forumcommunity.net/?t=56443955&p=396434984)
 
 ### What is RunAsDate?
 

--- a/guides/HeartGold and SoulSilver/Using Runasdate to RNG Initial Seed.md
+++ b/guides/HeartGold and SoulSilver/Using Runasdate to RNG Initial Seed.md
@@ -11,8 +11,9 @@ Note: This guide assumes that you have found your Target Seed, and that you know
 
 ## Tools
 
+- Desmume
+  - [Setup Desmume for RNG](https://www.pokemonrng.com/desmume-setup)
 - [RunAsDate](https://www.nirsoft.net/utils/run_as_date.html) : Take care to choose the right version (32 or 64 bits) for your computer.
-- [Lua Scripts for Gen 4](http://pokerng.forumcommunity.net/?t=56443955&p=396434984)
 
 ### What is RunAsDate?
 


### PR DESCRIPTION
Gen 4 and 5 guides had outdated links to tools, and didn't all mention how to setup Desmume for RNG. This PR updates all Gen 4 and 5 guides to have a consistent and up to date tools section.

Guides edited:
- DPPt Initial Seed and Stationary 
- HGSS Initial Seed
- BW Entralink, Roamers, DS Parameters, Initial Seed
- B2W2 Dream Radar, Initial Seed