### PR TITLE
[Guides] Update Gens 6 & 7 Tools

### DIFF
--- a/guides/Omega Ruby and Alpha Sapphire/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Omega Ruby and Alpha Sapphire/Egg RNG With Masuda Method or Shiny Charm.md
@@ -11,12 +11,9 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc for Gen 6
-  - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
-  - [PCalc-xy](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
 
 ## Step 1: Enter RNG info
 

--- a/guides/Omega Ruby and Alpha Sapphire/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Omega Ruby and Alpha Sapphire/Egg RNG With Masuda Method or Shiny Charm.md
@@ -11,8 +11,7 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Enter RNG info

--- a/guides/Omega Ruby and Alpha Sapphire/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Omega Ruby and Alpha Sapphire/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -11,12 +11,9 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc for Gen 6
-  - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
-  - [PCalc-xy](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
 
 ## Step 1: Enter RNG info
 

--- a/guides/Omega Ruby and Alpha Sapphire/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Omega Ruby and Alpha Sapphire/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -11,8 +11,7 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Enter RNG info

--- a/guides/Omega Ruby and Alpha Sapphire/TID RNG Guide.md
+++ b/guides/Omega Ruby and Alpha Sapphire/TID RNG Guide.md
@@ -11,8 +11,7 @@ Note: If a save file is already present then it can be deleted by pressing `X+Y+
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - (Optional) A network connection
 

--- a/guides/Omega Ruby and Alpha Sapphire/TID RNG Guide.md
+++ b/guides/Omega Ruby and Alpha Sapphire/TID RNG Guide.md
@@ -11,10 +11,9 @@ Note: If a save file is already present then it can be deleted by pressing `X+Y+
 
 ## Tools
 
-- [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
-  - Make sure your game is updated to 1.4 for PCalc to work
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-  - Latest compiled version including latest commits can be found [here](https://ci.appveyor.com/project/wwwwwwzx/3dsrngtool/build/artifacts)
 - (Optional) A network connection
 
 ## Step 1: Setup 3DSRNGTool

--- a/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -16,8 +16,7 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- A 3DS with PCalc installed (Optional)
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- Optional: A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -16,11 +16,8 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- A 3DS with CFW (Custom Firmware) (Optional)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
-- PCalc (Optional)
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+- A 3DS with PCalc installed (Optional)
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -15,12 +15,11 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+## Tools
+
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Sun and Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -17,8 +17,7 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Set Up 3DSRNGTool

--- a/guides/Sun and Moon/Island Scan RNG.md
+++ b/guides/Sun and Moon/Island Scan RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for

--- a/guides/Sun and Moon/Island Scan RNG.md
+++ b/guides/Sun and Moon/Island Scan RNG.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
   - [List of Island Scan islands and days for SM](https://www.pokemonrng.com/misc-3ds-island-scan-sm)

--- a/guides/Sun and Moon/Mystery Gift.md
+++ b/guides/Sun and Moon/Mystery Gift.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 Before continuing with the guide it is recommended to be in the first PokeCenter (the one by the Pokemon School) and standing directly in front of the Delivery Man.

--- a/guides/Sun and Moon/Mystery Gift.md
+++ b/guides/Sun and Moon/Mystery Gift.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 Before continuing with the guide it is recommended to be in the first PokeCenter (the one by the Pokemon School) and standing directly in front of the Delivery Man.
 

--- a/guides/Sun and Moon/Stationary RNG.md
+++ b/guides/Sun and Moon/Stationary RNG.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ### Recomended reading
 

--- a/guides/Sun and Moon/Stationary RNG.md
+++ b/guides/Sun and Moon/Stationary RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ### Recomended reading

--- a/guides/Sun and Moon/Timeline Guide.md
+++ b/guides/Sun and Moon/Timeline Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.

--- a/guides/Sun and Moon/Timeline Guide.md
+++ b/guides/Sun and Moon/Timeline Guide.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.
 

--- a/guides/Sun and Moon/Timeline Leap Guide.md
+++ b/guides/Sun and Moon/Timeline Leap Guide.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Step 1: Find your target frame
 

--- a/guides/Sun and Moon/Timeline Leap Guide.md
+++ b/guides/Sun and Moon/Timeline Leap Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Find your target frame

--- a/guides/Sun and Moon/Timeline With Fidget Guide.md
+++ b/guides/Sun and Moon/Timeline With Fidget Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Create a timeline

--- a/guides/Sun and Moon/Timeline With Fidget Guide.md
+++ b/guides/Sun and Moon/Timeline With Fidget Guide.md
@@ -7,11 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Step 1: Create a timeline
 

--- a/guides/Sun and Moon/Wild RNG.md
+++ b/guides/Sun and Moon/Wild RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ```

--- a/guides/Sun and Moon/Wild RNG.md
+++ b/guides/Sun and Moon/Wild RNG.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ```
 Note: In the game you will have to use "honey" to initiate the wild encounter.

--- a/guides/Transporter/Transporter.md
+++ b/guides/Transporter/Transporter.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Useful note

--- a/guides/Transporter/Transporter.md
+++ b/guides/Transporter/Transporter.md
@@ -7,9 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- [PCalc Transporter](https://pokemonrng.com/downloads/pcalc/pcalc-tport.zip)
 
 ## Useful note
 

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -16,8 +16,7 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- A 3DS with PCalc installed (Optional)
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- Optional: A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG With Masuda Method or Shiny Charm.md
@@ -16,11 +16,8 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 ## Tools
 
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- A 3DS with CFW (Custom Firmware) (Optional)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
-- PCalc (Optional)
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
+- A 3DS with PCalc installed (Optional)
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -15,8 +15,7 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Set Up 3DSRNGTool

--- a/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/Ultra Sun and Ultra Moon/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -15,12 +15,9 @@ If an ESV matches a TSV (Trainer Shiny Value) then the egg will hatch shiny.
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 
 ## Step 1: Set Up 3DSRNGTool
 

--- a/guides/Ultra Sun and Ultra Moon/Island Scan.md
+++ b/guides/Ultra Sun and Ultra Moon/Island Scan.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for

--- a/guides/Ultra Sun and Ultra Moon/Island Scan.md
+++ b/guides/Ultra Sun and Ultra Moon/Island Scan.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 - The `honey` item
 - Have started an Island Scan and know the Pokemon you've scanned for
   - [List of Island Scan islands and days for USUM](https://www.pokemonrng.com/misc-3ds-island-scan-usum)

--- a/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
+++ b/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 Before continuing with the guide it is recommended to be in the first PokeCenter (the one by the Pokemon School) and standing directly in front of the Delivery Man.

--- a/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
+++ b/guides/Ultra Sun and Ultra Moon/Mystery Gift.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 Before continuing with the guide it is recommended to be in the first PokeCenter (the one by the Pokemon School) and standing directly in front of the Delivery Man.
 

--- a/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Recommended reading/references

--- a/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/SOS RNG Guide.md
@@ -7,11 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 
 ## Recommended reading/references
 

--- a/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ### Recomended reading
 

--- a/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ### Recomended reading

--- a/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
@@ -7,11 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 - [3DSRNGTool README](https://github.com/wwwwwwzx/3DSRNGTool/blob/master/README.md#final-screen) - list of final screens before Pokemon are generated
 
 ```

--- a/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Stationary Wormhole RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - [3DSRNGTool README](https://github.com/wwwwwwzx/3DSRNGTool/blob/master/README.md#final-screen) - list of final screens before Pokemon are generated
 

--- a/guides/Ultra Sun and Ultra Moon/Timeline Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.

--- a/guides/Ultra Sun and Ultra Moon/Timeline Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline Guide.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 Before continuing with the guide it is recommended to be in the place you wish to RNG.
 

--- a/guides/Ultra Sun and Ultra Moon/Timeline Leap Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline Leap Guide.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ## Step 1: Find your target frame
 

--- a/guides/Ultra Sun and Ultra Moon/Timeline Leap Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline Leap Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Find your target frame

--- a/guides/Ultra Sun and Ultra Moon/Timeline With Fidget Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline With Fidget Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Create a timeline

--- a/guides/Ultra Sun and Ultra Moon/Timeline With Fidget Guide.md
+++ b/guides/Ultra Sun and Ultra Moon/Timeline With Fidget Guide.md
@@ -7,11 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
 
 ## Step 1: Create a timeline
 

--- a/guides/Ultra Sun and Ultra Moon/Wild RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Wild RNG.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ```

--- a/guides/Ultra Sun and Ultra Moon/Wild RNG.md
+++ b/guides/Ultra Sun and Ultra Moon/Wild RNG.md
@@ -7,12 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc
-  - [Ultra Sun/Ultra Moon](https://pokemonrng.com/downloads/pcalc/pcalc-usum.zip)
-  - [Sun/Moon](https://pokemonrng.com/downloads/pcalc/pcalc-sm.zip)
 
 ```
 Note: In the game you will have to use "honey" to initiate the wild encounter.

--- a/guides/X and Y/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/X and Y/Egg RNG With Masuda Method or Shiny Charm.md
@@ -11,12 +11,9 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc for Gen 6
-  - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
-  - [PCalc-xy](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
 
 ## Step 1: Enter RNG info
 

--- a/guides/X and Y/Egg RNG With Masuda Method or Shiny Charm.md
+++ b/guides/X and Y/Egg RNG With Masuda Method or Shiny Charm.md
@@ -11,8 +11,7 @@ Note: This method is different than using no Masuda or without having the Shiny 
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Enter RNG info

--- a/guides/X and Y/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/X and Y/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -11,12 +11,9 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- PCalc for Gen 6
-  - [PCalc-oras](https://pokemonrng.com/downloads/pcalc/pcalc-oras.zip)
-  - [PCalc-xy](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
 
 ## Step 1: Enter RNG info
 

--- a/guides/X and Y/Egg RNG Without Masuda Method or Shiny Charm.md
+++ b/guides/X and Y/Egg RNG Without Masuda Method or Shiny Charm.md
@@ -11,8 +11,7 @@ Note: This method is different than using Masuda or with having the Shiny Charm.
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Step 1: Enter RNG info

--- a/guides/X and Y/Friend Safari RNG Guide.md
+++ b/guides/X and Y/Friend Safari RNG Guide.md
@@ -14,7 +14,7 @@ subCategory: 'Custom Firmware'
 ## Required Reading
 
 - [TinyMT Timeline](https://github.com/wwwwwwzx/3DSRNGTool/wiki/Gen6-TinyMT-Timeline-Calibration)
-- [NTR Helper Usage](https://github.com/wwwwwwzx/3DSRNGTool/wiki/NTR-Helper-Usage)
+- [NTR Helper Usage](https://www.pokemonrng.com/ntr-helper-usage)
 
 ## Explanation of TinyMT frames within Tiny Timeline Tool
 

--- a/guides/X and Y/Friend Safari RNG Guide.md
+++ b/guides/X and Y/Friend Safari RNG Guide.md
@@ -7,8 +7,9 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
-- [PCalc for XY](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
 
 ## Required Reading
 

--- a/guides/X and Y/Friend Safari RNG Guide.md
+++ b/guides/X and Y/Friend Safari RNG Guide.md
@@ -7,8 +7,7 @@ subCategory: 'Custom Firmware'
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 
 ## Required Reading

--- a/guides/X and Y/XY Trainer ID, Secret ID, and TSV RNG Guide.md
+++ b/guides/X and Y/XY Trainer ID, Secret ID, and TSV RNG Guide.md
@@ -13,8 +13,7 @@ Make sure to back up your save file using a save file manager such as [Checkpoin
 
 ## Tools
 
-- A 3DS with PCalc installed
-  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
+- A 3DS with PCalc ([PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc))
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - (Optional) A network connection
 

--- a/guides/X and Y/XY Trainer ID, Secret ID, and TSV RNG Guide.md
+++ b/guides/X and Y/XY Trainer ID, Secret ID, and TSV RNG Guide.md
@@ -13,10 +13,8 @@ Make sure to back up your save file using a save file manager such as [Checkpoin
 
 ## Tools
 
-- A 3DS with CFW (Custom Firmware)
-  - https://3ds.hacks.guide/ has instructions for installing CFW
-- [PCalc for X/Y](https://pokemonrng.com/downloads/pcalc/pcalc-xy.zip)
-  - [Here](https://www.pokemonrng.com/misc-3ds-installing-pcalc) is a guide on how to install PCalc
+- A 3DS with PCalc installed
+  - [PCalc Install Guide](https://www.pokemonrng.com/misc-3ds-installing-pcalc)
 - [3DSRNGTool](https://github.com/wwwwwwzx/3DSRNGTool/releases)
 - (Optional) A network connection
 


### PR DESCRIPTION
This updates all Gen 6 and 7 guides to have the same Tools section with links to install pcalc guide and updated 3DSRNGTool links. No longer do we have to link to each specific pcalc version in each guide, all pcalc links are now in the install pcalc guide.

Closes #176 