### PR TITLE
Update Using IPS Patches with Luma and Citra.md

### DIFF
--- a/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
+++ b/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
@@ -17,7 +17,9 @@ For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 
 ## Using IPS files with Citra
 
-See Luma instructios, and the SDMC folder is the SD card.
+1. Right-click your game in Citra
+2. Select "Open Mod Location".
+3. Copy your code.ips into that folder. 
 
 ## Merging patches with IPSPatcher.js
 

--- a/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
+++ b/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
@@ -18,8 +18,8 @@ For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 ## Using IPS files with Citra
 
 1. Right-click your game in Citra
-2. Select "Open Mods Location" to opsn the mods folder.
-3. Copy your code.ips into the mods folder folder. 
+2. Select "Open Mods Location" to open the mods folder
+3. Copy your `code.ips` into the mods folder 
 
 ## Merging patches with IPSPatcher.js
 

--- a/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
+++ b/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
@@ -17,7 +17,7 @@ For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 
 ## Using IPS files with Citra
 
-1. Right-click your game in Citra
+1. Right click your game in Citra
 2. Select "Open Mods Location" to open the mods folder
 3. Copy your `code.ips` into the mods folder 
 

--- a/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
+++ b/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
@@ -18,8 +18,8 @@ For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 ## Using IPS files with Citra
 
 1. Right-click your game in Citra
-2. Select "Open Mod Location".
-3. Copy your code.ips into that folder. 
+2. Select "Open Mods Location" to opsn the mods folder.
+3. Copy your code.ips into the mods folder folder. 
 
 ## Merging patches with IPSPatcher.js
 

--- a/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
+++ b/guides/Tools and Emulators/Using IPS Patches with Luma and Citra.md
@@ -17,11 +17,7 @@ For example, Ultra Moon would be `/luma/title/00040000001B5100/code.ips`
 
 ## Using IPS files with Citra
 
-1. Right click on your game in Citra
-2. Open the update directory
-3. Make a new folder called `_your .app file_.exefsdir`
-   - For example, Ultra Moon's update would be `00000001.app.exefsdir`
-4. Put the `code.ips` in the new folder
+See Luma instructios, and the SDMC folder is the SD card.
 
 ## Merging patches with IPSPatcher.js
 


### PR DESCRIPTION
# Guide Details

## I want to (select one)

- [ ] Add a guide
- [x] Modify an existing guide

## Games affected

Everything on Citra

## Type of RNG

N/A

## Language

English

## Notes

Citra does not have an update folder for a game until the game has had an update installed. Instead, we use a plug-in loader similar to Luma's with the same file organization.
