### PR TITLE
Refactor Lcrng with generic constants and reverse iterators

### DIFF
--- a/rng_tools/src/generators/gen3/egg/emerald_held.rs
+++ b/rng_tools/src/generators/gen3/egg/emerald_held.rs
@@ -1,5 +1,5 @@
 use crate::Nature;
-use crate::rng::lcrng::Lcrng;
+use crate::rng::lcrng::Pokerng;
 use crate::rng::{Rng, StateIterator};
 use crate::{Gender, Species, gen3_shiny};
 use serde::{Deserialize, Serialize};
@@ -117,7 +117,7 @@ pub struct Egg3HeldOptions {
 
 #[wasm_bindgen]
 pub fn emerald_egg_held_states(opts: &Egg3HeldOptions) -> Vec<Gen3HeldEgg> {
-    let mut result = StateIterator::new(Lcrng::new_prng(0))
+    let mut result = StateIterator::new(Pokerng::new(0))
         .enumerate()
         .skip(opts.initial_advances)
         .take(opts.max_advances.saturating_add(1))
@@ -128,7 +128,7 @@ pub fn emerald_egg_held_states(opts: &Egg3HeldOptions) -> Vec<Gen3HeldEgg> {
 }
 
 fn generate_redraw_states(
-    mut rng: Lcrng,
+    mut rng: Pokerng,
     opts: &Egg3HeldOptions,
     advance: usize,
 ) -> Vec<Gen3HeldEgg> {
@@ -164,7 +164,7 @@ fn generate_redraw_states(
 }
 
 fn generate_state(
-    mut go: Lcrng,
+    mut go: Pokerng,
     calibration: u16,
     female_has_everstone: bool,
     female_nature: Nature,
@@ -179,7 +179,7 @@ fn generate_state(
     let offset = (redraws as u16).wrapping_mul(3).wrapping_add(calibration) as u32;
     let held_advance = (advance).wrapping_sub(calibration.into());
     let seed = ((advance).wrapping_add(1).wrapping_sub(offset)) & 0xffff;
-    let mut trng = Lcrng::new_prng(seed);
+    let mut trng = Pokerng::new(seed);
 
     if !use_everstone {
         let pid = (go.rand_max::<u16>(0xfffe) + 1) as u32 | ((trng.rand::<u16>() as u32) << 16);

--- a/rng_tools/src/generators/gen3/egg/emerald_pickup.rs
+++ b/rng_tools/src/generators/gen3/egg/emerald_pickup.rs
@@ -1,4 +1,4 @@
-use crate::rng::lcrng::Lcrng;
+use crate::rng::lcrng::Pokerng;
 use crate::rng::{Rng, StateIterator};
 use crate::{
     G3Idx::{self, *},
@@ -65,7 +65,7 @@ pub struct Egg3PickupState {
 
 #[wasm_bindgen]
 pub fn emerald_egg_pickup_states(opts: &Egg3PickupOptions) -> Vec<Egg3PickupState> {
-    StateIterator::new(Lcrng::new_prng(opts.seed))
+    StateIterator::new(Pokerng::new(opts.seed))
         .enumerate()
         .skip(opts.initial_advances)
         .take(opts.max_advances.saturating_add(1))
@@ -86,7 +86,7 @@ pub fn emerald_egg_pickup_states(opts: &Egg3PickupOptions) -> Vec<Egg3PickupStat
         .collect()
 }
 
-fn generate_pickup_ivs(opts: &Egg3PickupOptions, mut rng: Lcrng) -> Ivs {
+fn generate_pickup_ivs(opts: &Egg3PickupOptions, mut rng: Pokerng) -> Ivs {
     rng.advance(opts.method.iv1_advance());
     let iv1 = rng.rand::<u16>();
     rng.advance(opts.method.iv2_advance());
@@ -640,17 +640,20 @@ mod test {
         };
 
         let result = emerald_egg_pickup_states(&opts);
-        assert_eq!(result, [Egg3PickupState {
-            advance: 5,
-            ivs: Ivs {
-                hp: 12,
-                atk: 22,
-                def: 24,
-                spa: 10,
-                spd: 11,
-                spe: 12
-            }
-        }]);
+        assert_eq!(
+            result,
+            [Egg3PickupState {
+                advance: 5,
+                ivs: Ivs {
+                    hp: 12,
+                    atk: 22,
+                    def: 24,
+                    spa: 10,
+                    spd: 11,
+                    spe: 12
+                }
+            }]
+        );
     }
 
     #[test]

--- a/rng_tools/src/generators/gen3/feebas_sid.rs
+++ b/rng_tools/src/generators/gen3/feebas_sid.rs
@@ -1,4 +1,4 @@
-use crate::rng::lcrng::Lcrng;
+use crate::rng::lcrng::Pokerng;
 use crate::rng::{Rng, StateIterator};
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
@@ -12,7 +12,7 @@ pub struct FeebasSidResult {
     pub vblanks: u8,
 }
 
-fn generate_feebas_seed(mut rng: Lcrng) -> u16 {
+fn generate_feebas_seed(mut rng: Pokerng) -> u16 {
     let mut trends = Vec::new();
     for _ in 0..5 {
         rng.advance(4);
@@ -45,7 +45,7 @@ pub fn emerald_sid_from_feebas_seed(
     initial_advances: usize,
     max_advances: usize,
 ) -> Vec<FeebasSidResult> {
-    StateIterator::new(Lcrng::new_prng(tid.into()))
+    StateIterator::new(Pokerng::new(tid.into()))
         .enumerate()
         .skip(initial_advances)
         .take(max_advances)
@@ -81,7 +81,7 @@ pub fn rs_sid_from_feebas_seed(
     initial_advances: usize,
     max_advances: usize,
 ) -> Vec<FeebasSidResult> {
-    StateIterator::new(Lcrng::new_prng(0x5a0))
+    StateIterator::new(Pokerng::new(0x5a0))
         .enumerate()
         .skip(initial_advances)
         .take(max_advances.saturating_add(1))
@@ -123,114 +123,120 @@ mod tests {
 
     #[test]
     fn test_generate_feebas_seed() {
-        let result = generate_feebas_seed(Lcrng::new_prng(0xaabb));
+        let result = generate_feebas_seed(Pokerng::new(0xaabb));
         assert_eq!(result, 41779);
     }
 
     #[test]
     fn test_emerald_sid_from_spots() {
         let results = emerald_sid_from_feebas_seed(14223, 0xad4f, 0, 300_000);
-        assert_eq!(results, [
-            FeebasSidResult {
-                sid: 34159,
-                advances: 1810,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 27105,
-                advances: 1811,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 30561,
-                advances: 282651,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 31118,
-                advances: 282652,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 27948,
-                advances: 282657,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 39625,
-                advances: 282658,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 39625,
-                advances: 282658,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 57826,
-                advances: 282659,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 28480,
-                advances: 282664,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 4087,
-                advances: 282665,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 4087,
-                advances: 282665,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 53059,
-                advances: 282666,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 61650,
-                advances: 282671,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 42187,
-                advances: 282672,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 42187,
-                advances: 282672,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 53956,
-                advances: 282673,
-                vblanks: 2
-            },
-            FeebasSidResult {
-                sid: 53956,
-                advances: 282673,
-                vblanks: 3
-            },
-            FeebasSidResult {
-                sid: 53173,
-                advances: 282674,
-                vblanks: 2
-            },
-        ])
+        assert_eq!(
+            results,
+            [
+                FeebasSidResult {
+                    sid: 34159,
+                    advances: 1810,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 27105,
+                    advances: 1811,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 30561,
+                    advances: 282651,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 31118,
+                    advances: 282652,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 27948,
+                    advances: 282657,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 39625,
+                    advances: 282658,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 39625,
+                    advances: 282658,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 57826,
+                    advances: 282659,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 28480,
+                    advances: 282664,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 4087,
+                    advances: 282665,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 4087,
+                    advances: 282665,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 53059,
+                    advances: 282666,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 61650,
+                    advances: 282671,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 42187,
+                    advances: 282672,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 42187,
+                    advances: 282672,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 53956,
+                    advances: 282673,
+                    vblanks: 2
+                },
+                FeebasSidResult {
+                    sid: 53956,
+                    advances: 282673,
+                    vblanks: 3
+                },
+                FeebasSidResult {
+                    sid: 53173,
+                    advances: 282674,
+                    vblanks: 2
+                },
+            ]
+        )
     }
 
     #[test]
     fn test_rs_sid_from_spots() {
         let results = rs_sid_from_feebas_seed(52548, 0xebf6, 0, 500_000);
-        assert_eq!(results, [FeebasSidResult {
-            sid: 4132,
-            advances: 90715,
-            vblanks: 2
-        }]);
+        assert_eq!(
+            results,
+            [FeebasSidResult {
+                sid: 4132,
+                advances: 90715,
+                vblanks: 2
+            }]
+        );
     }
 }

--- a/rng_tools/src/generators/gen3/stationary.rs
+++ b/rng_tools/src/generators/gen3/stationary.rs
@@ -1,4 +1,4 @@
-use crate::rng::lcrng::Lcrng;
+use crate::rng::lcrng::Pokerng;
 use crate::rng::{Rng, StateIterator};
 use crate::{Gender, IvFilter, Ivs, Nature, Species, gen3_shiny};
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ pub struct Static3Options {
 
 #[wasm_bindgen]
 pub fn gen3_static_states(opts: &Static3Options) -> Vec<Static3Result> {
-    StateIterator::new(Lcrng::new_prng(opts.seed))
+    StateIterator::new(Pokerng::new(opts.seed))
         .skip(opts.offset)
         .enumerate()
         .skip(opts.initial_advances)
@@ -93,7 +93,7 @@ pub fn gen3_static_states(opts: &Static3Options) -> Vec<Static3Result> {
 }
 
 fn generate_gen3_static_state(
-    mut rng: Lcrng,
+    mut rng: Pokerng,
     opts: &Static3Options,
     advance: usize,
 ) -> Static3Result {

--- a/rng_tools/src/rng/lcrng.rs
+++ b/rng_tools/src/rng/lcrng.rs
@@ -1,40 +1,25 @@
 use super::rng_trait::{GetMaxRand, GetRand, Rng};
-use std::iter::{DoubleEndedIterator, Iterator, Skip};
+use std::iter::{DoubleEndedIterator, Iterator, Rev, Skip};
+
+pub type Pokerng = Lcrng<0x6073, 0x41c64e6d, 0xa3561a1, 0xeeb9eb65>;
 
 #[derive(Debug, Clone, Copy)]
-pub struct Lcrng {
+pub struct Lcrng<const ADD: u32, const MUL: u32, const P_ADD: u32, const P_MUL: u32> {
     state: u32,
-    add: u32,
-    mul: u32,
-    prev_add: u32,
-    prev_mul: u32,
 }
 
-impl Lcrng {
-    fn new(seed: u32, add: u32, mul: u32, prev_add: u32, prev_mul: u32) -> Self {
-        Self {
-            state: seed,
-            add,
-            mul,
-            prev_mul,
-            prev_add,
-        }
-    }
-
-    pub fn new_prng(seed: u32) -> Self {
-        Self::new(seed, 0x6073, 0x41c64e6d, 0xa3561a1, 0xeeb9eb65)
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> Lcrng<A, M, PA, PM> {
+    pub fn new(seed: u32) -> Self {
+        Self { state: seed }
     }
 
     fn prev_state(&mut self) -> u32 {
-        self.state = self
-            .state
-            .wrapping_mul(self.prev_mul)
-            .wrapping_add(self.prev_add);
+        self.state = self.state.wrapping_mul(PM).wrapping_add(PA);
         self.state
     }
 
     fn next_state(&mut self) -> u32 {
-        self.state = self.state.wrapping_mul(self.mul).wrapping_add(self.add);
+        self.state = self.state.wrapping_mul(M).wrapping_add(A);
         self.state
     }
 
@@ -43,7 +28,7 @@ impl Lcrng {
     }
 }
 
-impl Iterator for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> Iterator for Lcrng<A, M, PA, PM> {
     type Item = u32;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -51,55 +36,93 @@ impl Iterator for Lcrng {
     }
 }
 
-impl DoubleEndedIterator for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> DoubleEndedIterator
+    for Lcrng<A, M, PA, PM>
+{
     fn next_back(&mut self) -> Option<Self::Item> {
         Some(self.prev_state())
     }
 }
 
-impl GetRand<u8> for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u8> for Lcrng<A, M, PA, PM> {
     fn get(&mut self) -> u8 {
         self.next_u16() as u8
     }
 }
 
-impl GetRand<u16> for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u16>
+    for Lcrng<A, M, PA, PM>
+{
     fn get(&mut self) -> u16 {
         self.next_u16()
     }
 }
 
-impl GetMaxRand<u16> for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetMaxRand<u16>
+    for Lcrng<A, M, PA, PM>
+{
     fn get_max(&mut self, max: u16) -> u16 {
         ((self.next().unwrap_or_default() >> 16) as u16) % max
     }
 }
 
-impl GetRand<u32> for Lcrng {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u32>
+    for Lcrng<A, M, PA, PM>
+{
     fn get(&mut self) -> u32 {
-        (self.next_u16() as u32) << 16 | self.next_u16() as u32
+        self.next_state()
     }
 }
 
-impl GetRand<u8> for Skip<Lcrng> {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u8>
+    for Skip<Lcrng<A, M, PA, PM>>
+{
     fn get(&mut self) -> u8 {
         GetRand::<u16>::get(self) as u8
     }
 }
 
-impl GetRand<u16> for Skip<Lcrng> {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u16>
+    for Skip<Lcrng<A, M, PA, PM>>
+{
     fn get(&mut self) -> u16 {
         (self.next().unwrap_or_default() >> 16) as u16
     }
 }
 
-impl GetRand<u32> for Skip<Lcrng> {
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u32>
+    for Skip<Lcrng<A, M, PA, PM>>
+{
     fn get(&mut self) -> u32 {
-        (GetRand::<u16>::get(self) as u32) << 16 | GetRand::<u16>::get(self) as u32
+        self.next().unwrap_or_default()
     }
 }
 
-impl Rng for Lcrng {}
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u8>
+    for Rev<Lcrng<A, M, PA, PM>>
+{
+    fn get(&mut self) -> u8 {
+        GetRand::<u16>::get(self) as u8
+    }
+}
+
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u16>
+    for Rev<Lcrng<A, M, PA, PM>>
+{
+    fn get(&mut self) -> u16 {
+        (self.next().unwrap_or_default() >> 16) as u16
+    }
+}
+
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> GetRand<u32>
+    for Rev<Lcrng<A, M, PA, PM>>
+{
+    fn get(&mut self) -> u32 {
+        self.next().unwrap()
+    }
+}
+
+impl<const A: u32, const M: u32, const PA: u32, const PM: u32> Rng for Lcrng<A, M, PA, PM> {}
 
 #[cfg(test)]
 mod test {
@@ -253,7 +276,7 @@ mod test {
             0xa6a8fff5, 0xa07001c4, 0x91d2d8e7, 0xbe871cce, 0xdfa26829, 0xac9937e8,
         ];
 
-        let rng = Lcrng::new_prng(0);
+        let rng = Pokerng::new(0);
 
         expected_results.into_iter().zip(rng).enumerate().for_each(
             |(advances, (expected, actual))| {
@@ -264,23 +287,30 @@ mod test {
 
     #[test]
     fn can_reverse() {
-        let mut rng = Lcrng::new_prng(0);
+        let mut rng = Pokerng::new(0);
         assert_eq!(rng.nth(100), Some(0x172ebb67));
         assert_eq!(rng.nth_back(100), Some(0));
     }
 
     #[test]
+    fn can_rev_iterator() {
+        let mut rng = Pokerng::new(0xe97e7b6a).rev();
+        assert_eq!(rng.next(), Some(0x00006073));
+        assert_eq!(rng.rand::<u32>(), 0);
+    }
+
+    #[test]
     fn demo_rands() {
         // Get free iteration tools, like advancing and collecting
-        let result: Vec<u32> = Lcrng::new_prng(0).skip(0).take(4).collect();
+        let result: Vec<u32> = Pokerng::new(0).skip(0).take(4).collect();
         assert_eq!(result, [0x00006073, 0xe97e7b6a, 0x52713895, 0x31b0dde4]);
 
         // Advance without chaining
-        let mut rng = Lcrng::new_prng(0);
+        let mut rng = Pokerng::new(0);
         rng.advance(1);
         assert_eq!(rng.rand::<u16>(), 0xe97e);
 
         // Custom behavior for different types, such as u32 being u16 << 16 | u16
-        assert_eq!(rng.rand::<u32>(), 0x527131b0);
+        assert_eq!(rng.rand::<u32>(), 0x52713895);
     }
 }

--- a/rng_tools/src/rng/rng_trait.rs
+++ b/rng_tools/src/rng/rng_trait.rs
@@ -1,4 +1,4 @@
-use std::iter::Skip;
+use std::iter::{Rev, Skip};
 use std::ops::Rem;
 
 pub trait GetRand<T> {
@@ -33,3 +33,4 @@ pub trait Rng: Iterator {
 }
 
 impl<T: Iterator> Rng for Skip<T> {}
+impl<T: Iterator + DoubleEndedIterator> Rng for Rev<T> {}


### PR DESCRIPTION
I also tweaked GetRand<u32> to return the next state rather than the two u16s being OR'd. Gen 3 doesn't have the same return case as the newer generations