### PR TITLE
Remove HexString and DecimalString

### DIFF
--- a/cypress/e2e/gen3/tid-sid.cy.ts
+++ b/cypress/e2e/gen3/tid-sid.cy.ts
@@ -6,13 +6,13 @@ describe("rs", () => {
     testRngTool<Omit<FormState, "tid" | "date" | "time" | "filter">>({
       url: "/rs-tidsid-generator",
       form: {
-        seed: "aabb",
+        seed: "a000",
         offset: "10",
         initial_advances: "100",
-        max_advances: "90000",
+        max_advances: "100000",
         rs_input_type: { type: "select", value: "Seed" },
       },
-      partialFirstColumnValues: ["18614", "0", "59190", "7398"],
+      partialFirstColumnValues: ["97934", "0", "31101", "3887"],
     });
   });
 });

--- a/cypress/e2e/gen6/oras-mirage-spots.cy.ts
+++ b/cypress/e2e/gen6/oras-mirage-spots.cy.ts
@@ -3,11 +3,11 @@ import type { FormState } from "~/rngToolsUi/gen6/orasMirageSpot";
 
 describe("rng tool", () => {
   it("works", () => {
-    testRngTool<Omit<FormState, "startDate" | "maxAdvances">>({
+    testRngTool<Omit<FormState, "start_date" | "max_advances">>({
       url: "/oras-mirage-spots",
       form: {
         seed: "aabbccdd",
-        filterSpecies: { type: "select", value: "Ditto" },
+        filter_species: { type: "select", value: "Ditto" },
         tid: "12345",
       },
     });

--- a/cypress/e2e/gen6/retail-oras-tid.cy.ts
+++ b/cypress/e2e/gen6/retail-oras-tid.cy.ts
@@ -7,9 +7,9 @@ describe("rng tool", () => {
       url: "/retail-oras-tid",
       form: {
         seed: "aabbccdd",
-        initialAdvances: "10",
-        maxAdvances: "100",
-        onlyCurrentSeed: { type: "switch", value: true },
+        initial_advances: "10",
+        max_advances: "100",
+        only_current_seed: { type: "switch", value: true },
       },
     });
   });

--- a/cypress/e2e/gen6/xy-pokeradar.cy.ts
+++ b/cypress/e2e/gen6/xy-pokeradar.cy.ts
@@ -6,12 +6,12 @@ describe("rng tool", () => {
     testRngTool<Omit<FormState, "date" | "time">>({
       url: "/xy-pokeradar",
       form: {
-        bonusMusic: { type: "switch", value: false },
-        filterShiny: { type: "switch", value: false },
+        bonus_music: { type: "switch", value: false },
+        filter_shiny: { type: "switch", value: false },
         chain: "10",
-        initialAdvances: "10",
-        maxAdvances: "10",
-        partyCount: "6",
+        initial_advances: "10",
+        max_advances: "10",
+        party_count: "6",
         state0: "aaaaaaaa",
         state1: "bbbbbbbb",
         state2: "cccccccc",

--- a/src/components/idFilter.tsx
+++ b/src/components/idFilter.tsx
@@ -1,7 +1,7 @@
 import { GenericForm, GuaranteeFormNameType } from "~/types/form";
 import { Select } from "./select";
 import { Flex } from "./flex";
-import { Input } from "./input";
+import { NumberInput } from "./numberInput";
 import { useFormikContext } from "formik";
 import { IdFilter } from "~/types/id";
 
@@ -44,25 +44,27 @@ export const FormikIdFilter = <FormState extends GenericForm>({
         }}
       />
       {value.type !== "none" && (
-        <Input
+        <NumberInput
           fullFlex
+          numType={value.type === "pid" ? "hex" : "decimal"}
           value={value.value0}
-          onChange={(event) => {
+          onChange={(fieldValue) => {
             formik.setFieldValue(name, {
               ...value,
-              value0: event.target.value,
+              value0: fieldValue,
             });
           }}
         />
       )}
       {(value.type === "tidpid" || value.type === "tidsid") && (
-        <Input
+        <NumberInput
           fullFlex
+          numType={value.type === "tidpid" ? "hex" : "decimal"}
           value={value.value1}
-          onChange={(event) => {
+          onChange={(fieldValue) => {
             formik.setFieldValue(name, {
               ...value,
-              value1: event.target.value,
+              value1: fieldValue,
             });
           }}
         />

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -11,6 +11,7 @@ export { Image } from "./image";
 export { MetaTags } from "./metaTags";
 export { List, ListItem } from "./list";
 export { FormikInput } from "./input";
+export { FormikNumberInput } from "./numberInput";
 export { Form } from "./form";
 export { FormFieldTable, type Field } from "./formFieldTable";
 export {

--- a/src/components/numberInput.tsx
+++ b/src/components/numberInput.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { Input } from "./input";
+import { capPrecision } from "~/utils/number";
+import { GenericForm, GuaranteeFormNameType } from "~/types/form";
+import { useFormikContext } from "formik";
+import { match } from "ts-pattern";
+
+const serializers = {
+  hex: (num: number | undefined) => num?.toString(16),
+  decimal: (num: number | undefined) => num?.toString(10),
+  float: (num: number | undefined) => num?.toString(10),
+};
+
+const deserializers = {
+  hex: (str: string) => parseInt(str, 16),
+  decimal: (str: string) => parseInt(str, 10),
+  float: (str: string) => capPrecision(parseInt(str, 10)),
+};
+
+type NumberInputProps = {
+  disabled?: boolean;
+  fullFlex?: boolean;
+  name?: string;
+  value?: number | undefined;
+  numType: "hex" | "decimal" | "float";
+  onChange: (value: number | undefined) => void;
+};
+
+export const NumberInput = ({
+  name,
+  numType,
+  value,
+  onChange,
+  ...props
+}: NumberInputProps) => {
+  const serialize = serializers[numType];
+  const deserialize = deserializers[numType];
+  // Tracking negative allows us to show only '-', which is not a valid number
+  const [isNegative, setIsNegative] = React.useState(false);
+
+  const _onChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+
+      setIsNegative(value.includes("-"));
+
+      if (value.length === 0 || value === "-") {
+        onChange(undefined);
+        return;
+      }
+
+      const deserialized = deserialize(value);
+
+      if (!isNaN(deserialized)) {
+        onChange(deserialized);
+      }
+    },
+    [deserialize, onChange],
+  );
+
+  const displayedValue = match({ value, isNegative })
+    .with({ value: undefined, isNegative: false }, () => "")
+    .with({ value: undefined, isNegative: true }, () => "-")
+    .otherwise((matched) => serialize(matched.value));
+
+  return (
+    <Input {...props} name={name} onChange={_onChange} value={displayedValue} />
+  );
+};
+
+type FormikNumberInputProps<FormState extends GenericForm> = {
+  disabled?: boolean;
+  numType: "hex" | "decimal" | "float";
+  name: GuaranteeFormNameType<FormState, number | undefined>;
+};
+
+export const FormikNumberInput = <FormState extends GenericForm>({
+  name,
+  ...props
+}: FormikNumberInputProps<FormState>) => {
+  type Name = typeof name;
+  const { values, setFieldValue } =
+    useFormikContext<Record<Name, number | undefined>>();
+
+  const value = values[name];
+
+  const onChange = React.useCallback(
+    (value: number | undefined) => {
+      setFieldValue(name, value);
+    },
+    [setFieldValue, name],
+  );
+
+  return (
+    <NumberInput {...props} name={name} onChange={onChange} value={value} />
+  );
+};

--- a/src/rngToolsUi/gen2/crystalPokemon.tsx
+++ b/src/rngToolsUi/gen2/crystalPokemon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   Icon,
   FormikSelect,
@@ -8,14 +8,6 @@ import {
   RngToolSubmit,
 } from "~/components";
 import { rngTools, Gen2PokeFilter, type Gen2Spread } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 import { useTranslator, Translations, Translator } from "~/utils/siteLanguage";
 
 const englishTranslations = {
@@ -104,22 +96,22 @@ type Field = {
 };
 
 export type FormState = {
-  div: HexString;
-  adivIndex: DecimalString;
-  sdivIndex: DecimalString;
-  state: HexString;
-  startAdvance: DecimalString;
-  advanceCount: DecimalString;
+  div: number;
+  adivIndex: number;
+  sdivIndex: number;
+  state: number;
+  startAdvance: number;
+  advanceCount: number;
   filter: Gen2PokeFilter;
 };
 
 const initialValues: FormState = {
-  div: toHexString(0),
-  adivIndex: toDecimalString(0),
-  sdivIndex: toDecimalString(0),
-  state: toHexString(0),
-  startAdvance: toDecimalString(0),
-  advanceCount: toDecimalString(10000),
+  div: 0,
+  adivIndex: 0,
+  sdivIndex: 0,
+  state: 0,
+  startAdvance: 0,
+  advanceCount: 10000,
   filter: "Shiny",
 };
 
@@ -127,27 +119,39 @@ const getFields = (t: Translator<typeof translations>): Field[] => {
   return [
     {
       label: t("ADiv Index"),
-      input: <FormikInput<FormState> name="adivIndex" />,
+      input: (
+        <FormikNumberInput<FormState> name="adivIndex" numType="decimal" />
+      ),
     },
     {
       label: t("SDiv Index"),
-      input: <FormikInput<FormState> name="sdivIndex" />,
+      input: (
+        <FormikNumberInput<FormState> name="sdivIndex" numType="decimal" />
+      ),
     },
     {
       label: t("Div"),
-      input: <FormikInput<FormState> name="div" />,
+      input: <FormikNumberInput<FormState> name="div" numType="hex" />,
     },
     {
       label: t("State"),
-      input: <FormikInput<FormState> name="state" />,
+      input: <FormikNumberInput<FormState> name="state" numType="hex" />,
     },
     {
       label: t("Start Advance"),
-      input: <FormikInput<FormState> name="startAdvance" />,
+      input: (
+        <FormikNumberInput<FormState> name="startAdvance" numType="decimal" />
+      ),
     },
     {
       label: t("Advance Count"),
-      input: <FormikInput<FormState> name="advanceCount" disabled />,
+      input: (
+        <FormikNumberInput<FormState>
+          name="advanceCount"
+          disabled
+          numType="decimal"
+        />
+      ),
     },
     {
       label: t("Filter"),
@@ -187,23 +191,19 @@ export const Gen2PokemonRng = ({ type, language }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const div = fromHexString(opts.div) ?? 0;
-      const startAdvance = fromDecimalString(opts.startAdvance) ?? 0;
-      const advanceCount = fromDecimalString(opts.advanceCount) ?? 0;
-
       const generator =
         type === "starter"
           ? rngTools.crystal_generate_starters
           : rngTools.crystal_generate_celebi;
 
       const results = await generator(
-        div >>> 8,
-        div & 0xff,
-        fromDecimalString(opts.adivIndex) ?? 0,
-        fromDecimalString(opts.sdivIndex) ?? 0,
-        fromHexString(opts.state) ?? 0,
-        fromDecimalString(opts.startAdvance) ?? 0,
-        startAdvance + advanceCount,
+        opts.div >>> 8,
+        opts.div & 0xff,
+        opts.adivIndex,
+        opts.sdivIndex,
+        opts.state,
+        opts.startAdvance,
+        opts.startAdvance + opts.advanceCount,
         opts.filter,
       );
       setResults(results);

--- a/src/rngToolsUi/gen2/gen2Rng.tsx
+++ b/src/rngToolsUi/gen2/gen2Rng.tsx
@@ -1,20 +1,12 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
   Field,
 } from "~/components";
 import { rngTools } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 
 type RngState = {
   advance: number;
@@ -45,47 +37,55 @@ const columns: ResultColumn<RngState>[] = [
 ];
 
 type FormState = {
-  div: HexString;
-  adivIndex: DecimalString;
-  sdivIndex: DecimalString;
-  state: HexString;
-  startAdvance: DecimalString;
-  advanceCount: DecimalString;
+  div: number;
+  adivIndex: number;
+  sdivIndex: number;
+  state: number;
+  startAdvance: number;
+  advanceCount: number;
 };
 
 const initialValues: FormState = {
-  div: toHexString(0),
-  adivIndex: toDecimalString(0),
-  sdivIndex: toDecimalString(0),
-  state: toHexString(0),
-  startAdvance: toDecimalString(0),
-  advanceCount: toDecimalString(10000),
+  div: 0,
+  adivIndex: 0,
+  sdivIndex: 0,
+  state: 0,
+  startAdvance: 0,
+  advanceCount: 10000,
 };
 
 const fields: Field[] = [
   {
     label: "ADiv Index",
-    input: <FormikInput<FormState> name="adivIndex" />,
+    input: <FormikNumberInput<FormState> name="adivIndex" numType="decimal" />,
   },
   {
     label: "SDiv Index",
-    input: <FormikInput<FormState> name="sdivIndex" />,
+    input: <FormikNumberInput<FormState> name="sdivIndex" numType="decimal" />,
   },
   {
     label: "Div",
-    input: <FormikInput<FormState> name="div" />,
+    input: <FormikNumberInput<FormState> name="div" numType="hex" />,
   },
   {
     label: "State",
-    input: <FormikInput<FormState> name="state" />,
+    input: <FormikNumberInput<FormState> name="state" numType="hex" />,
   },
   {
     label: "Start Advance",
-    input: <FormikInput<FormState> name="startAdvance" />,
+    input: (
+      <FormikNumberInput<FormState> name="startAdvance" numType="decimal" />
+    ),
   },
   {
     label: "Advance Count",
-    input: <FormikInput<FormState> name="advanceCount" disabled />,
+    input: (
+      <FormikNumberInput<FormState>
+        name="advanceCount"
+        disabled
+        numType="decimal"
+      />
+    ),
   },
 ];
 
@@ -93,17 +93,14 @@ export const Gen2Rng = () => {
   const [results, setResults] = React.useState<RngState[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const div = fromHexString(opts.div) ?? 0;
-    const startAdvance = fromDecimalString(opts.startAdvance) ?? 0;
-    const advanceCount = fromDecimalString(opts.advanceCount) ?? 0;
     const results = await rngTools.gen2_generate_rng_states(
-      div >>> 8,
-      div & 0xff,
-      fromDecimalString(opts.adivIndex) ?? 0,
-      fromDecimalString(opts.sdivIndex) ?? 0,
-      fromHexString(opts.state) ?? 0,
-      startAdvance,
-      startAdvance + advanceCount,
+      opts.div >>> 8,
+      opts.div & 0xff,
+      opts.adivIndex,
+      opts.sdivIndex,
+      opts.state,
+      opts.startAdvance,
+      opts.startAdvance + opts.advanceCount,
     );
     setResults(
       results.map(({ add_div, sub_div, advance, rand }) => ({

--- a/src/rngToolsUi/gen3/emeraldHeldEgg.tsx
+++ b/src/rngToolsUi/gen3/emeraldHeldEgg.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   FormikSelect,
   Field,
@@ -16,11 +16,6 @@ import {
   Species,
   Gender,
 } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
 import { gen3Species } from "~/types/species";
 import { nature } from "~/types/nature";
 import { gender } from "~/types/gender";
@@ -47,17 +42,17 @@ const columns: ResultColumn<Gen3HeldEgg>[] = [
 ];
 
 export type FormState = {
-  delay: DecimalString;
-  initial_advances: DecimalString;
-  max_advances: DecimalString;
+  delay: number;
+  initial_advances: number;
+  max_advances: number;
   female_has_everstone: boolean;
   female_nature: Nature;
-  calibration: DecimalString;
-  min_redraw: DecimalString;
-  max_redraw: DecimalString;
+  calibration: number;
+  min_redraw: number;
+  max_redraw: number;
   compatability: Compatability;
-  tid: DecimalString;
-  sid: DecimalString;
+  tid: number;
+  sid: number;
   egg_species: Species;
   filter_shiny: boolean;
   filter_nature: Nature | "None";
@@ -65,17 +60,17 @@ export type FormState = {
 };
 
 const initialValues: FormState = {
-  delay: toDecimalString(0),
-  initial_advances: toDecimalString(100),
-  max_advances: toDecimalString(1000),
+  delay: 0,
+  initial_advances: 100,
+  max_advances: 1000,
   female_has_everstone: false,
   female_nature: "Adamant",
-  calibration: toDecimalString(18),
-  min_redraw: toDecimalString(0),
-  max_redraw: toDecimalString(5),
+  calibration: 18,
+  min_redraw: 0,
+  max_redraw: 5,
   compatability: "GetAlong",
-  tid: toDecimalString(0),
-  sid: toDecimalString(0),
+  tid: 0,
+  sid: 0,
   egg_species: "Bulbasaur",
   filter_shiny: false,
   filter_nature: "None",
@@ -137,35 +132,41 @@ const fields: Field[] = [
   },
   {
     label: "Calibration",
-    input: <FormikInput<FormState> name="calibration" />,
+    input: (
+      <FormikNumberInput<FormState> name="calibration" numType="decimal" />
+    ),
   },
   {
     label: "TID",
-    input: <FormikInput<FormState> name="tid" />,
+    input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
   },
   {
     label: "SID",
-    input: <FormikInput<FormState> name="sid" />,
+    input: <FormikNumberInput<FormState> name="sid" numType="decimal" />,
   },
   {
     label: "Initial advances",
-    input: <FormikInput<FormState> name="initial_advances" />,
+    input: (
+      <FormikNumberInput<FormState> name="initial_advances" numType="decimal" />
+    ),
   },
   {
     label: "Max advances",
-    input: <FormikInput<FormState> name="max_advances" />,
+    input: (
+      <FormikNumberInput<FormState> name="max_advances" numType="decimal" />
+    ),
   },
   {
     label: "Delay",
-    input: <FormikInput<FormState> name="delay" />,
+    input: <FormikNumberInput<FormState> name="delay" numType="decimal" />,
   },
   {
     label: "Min redraw",
-    input: <FormikInput<FormState> name="min_redraw" />,
+    input: <FormikNumberInput<FormState> name="min_redraw" numType="decimal" />,
   },
   {
     label: "Max redraw",
-    input: <FormikInput<FormState> name="max_redraw" />,
+    input: <FormikNumberInput<FormState> name="max_redraw" numType="decimal" />,
   },
   {
     label: "Filter shiny",
@@ -206,38 +207,8 @@ export const EmeraldHeldEgg = ({ lua = false }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const initialAdvances = fromDecimalString(opts.initial_advances);
-      const maxAdvances = fromDecimalString(opts.max_advances);
-      const calibration = fromDecimalString(opts.calibration);
-      const minRedraw = fromDecimalString(opts.min_redraw);
-      const maxRedraw = fromDecimalString(opts.max_redraw);
-      const tid = fromDecimalString(opts.tid);
-      const sid = fromDecimalString(opts.sid);
-      const delay = fromDecimalString(opts.delay);
-
-      if (
-        initialAdvances == null ||
-        maxAdvances == null ||
-        calibration == null ||
-        minRedraw == null ||
-        maxRedraw == null ||
-        tid == null ||
-        sid == null ||
-        delay == null
-      ) {
-        return;
-      }
-
       const results = await rngTools.emerald_egg_held_states({
         ...opts,
-        initial_advances: initialAdvances,
-        max_advances: maxAdvances,
-        calibration: calibration,
-        min_redraw: minRedraw,
-        max_redraw: maxRedraw,
-        tid,
-        sid,
-        delay,
         lua_adjustment: lua,
         filters: {
           shiny: opts.filter_shiny,

--- a/src/rngToolsUi/gen3/emeraldPickupEgg.tsx
+++ b/src/rngToolsUi/gen3/emeraldPickupEgg.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   FormikSelect,
   IvInput,
@@ -9,14 +9,6 @@ import {
   RngToolSubmit,
 } from "~/components";
 import { rngTools, Ivs, Gen3PickupMethod, Egg3PickupState } from "~/rngTools";
-import {
-  HexString,
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-  toHexString,
-  fromHexString,
-} from "~/utils/number";
 import { maxIvs, minIvs } from "~/types/ivs";
 import {
   flattenIvs,
@@ -32,10 +24,10 @@ const columns: ResultColumn<Result>[] = [
 ];
 
 export type FormState = {
-  delay: DecimalString;
-  seed: HexString;
-  initial_advances: DecimalString;
-  max_advances: DecimalString;
+  delay: number;
+  seed: number;
+  initial_advances: number;
+  max_advances: number;
   method: Gen3PickupMethod;
   parent1_ivs: Ivs;
   parent2_ivs: Ivs;
@@ -44,10 +36,10 @@ export type FormState = {
 };
 
 const initialValues: FormState = {
-  delay: toDecimalString(3),
-  seed: toHexString(0),
-  initial_advances: toDecimalString(100),
-  max_advances: toDecimalString(1000),
+  delay: 3,
+  seed: 0,
+  initial_advances: 100,
+  max_advances: 1000,
   method: "EmeraldBred",
   parent1_ivs: maxIvs,
   parent2_ivs: maxIvs,
@@ -58,19 +50,23 @@ const initialValues: FormState = {
 const fields: Field[] = [
   {
     label: "Seed",
-    input: <FormikInput<FormState> name="seed" />,
+    input: <FormikNumberInput<FormState> name="seed" numType="hex" />,
   },
   {
     label: "Initial advances",
-    input: <FormikInput<FormState> name="initial_advances" />,
+    input: (
+      <FormikNumberInput<FormState> name="initial_advances" numType="decimal" />
+    ),
   },
   {
     label: "Max advances",
-    input: <FormikInput<FormState> name="max_advances" />,
+    input: (
+      <FormikNumberInput<FormState> name="max_advances" numType="decimal" />
+    ),
   },
   {
     label: "Delay",
-    input: <FormikInput<FormState> name="delay" />,
+    input: <FormikNumberInput<FormState> name="delay" numType="decimal" />,
   },
   {
     label: "Parent 1 IVs",
@@ -112,26 +108,8 @@ export const EmeraldPickupEgg = ({ lua = false }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const initialAdvances = fromDecimalString(opts.initial_advances);
-      const maxAdvances = fromDecimalString(opts.max_advances);
-      const seed = fromHexString(opts.seed);
-      const delay = fromDecimalString(opts.delay);
-
-      if (
-        initialAdvances == null ||
-        maxAdvances == null ||
-        seed == null ||
-        delay == null
-      ) {
-        return;
-      }
-
       const results = await rngTools.emerald_egg_pickup_states({
         ...opts,
-        seed,
-        delay,
-        initial_advances: initialAdvances,
-        max_advances: maxAdvances,
         parent_ivs: [opts.parent1_ivs, opts.parent2_ivs],
         lua_adjustment: lua,
         filter: {

--- a/src/rngToolsUi/gen3/mirageIsland.tsx
+++ b/src/rngToolsUi/gen3/mirageIsland.tsx
@@ -1,11 +1,11 @@
-import { Field, RngToolForm, ResultColumn, RngToolSubmit } from "~/components";
 import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
+  Field,
+  RngToolForm,
+  ResultColumn,
+  RngToolSubmit,
+  FormikNumberInput,
+} from "~/components";
 import { FormikRadio } from "../../components/radio";
-import { FormikInput } from "../../components/input";
 
 import { rngTools, MirageIslandResult } from "~/rngTools";
 import React from "react";
@@ -63,12 +63,12 @@ type Battery = "Dead" | "Live";
 
 export type FormState = {
   battery: Battery;
-  rocketLaunchedCount: DecimalString;
+  rocketLaunchedCount: number;
 };
 
 const initialValues: FormState = {
   battery: "Live",
-  rocketLaunchedCount: toDecimalString(0),
+  rocketLaunchedCount: 0,
 };
 
 const generateResults = (
@@ -79,11 +79,8 @@ const generateResults = (
   if (values.battery === "Dead")
     return rngTools.mirage_island_calculate(initialSeed, 0, 0);
 
-  const rocketLaunchedCount =
-    fromDecimalString(values.rocketLaunchedCount) ?? 0;
-
   const RESULT_COUNT = 100;
-  const currentDay = clamp(rocketLaunchedCount * 7, 0, 0xffff);
+  const currentDay = clamp(values.rocketLaunchedCount * 7, 0, 0xffff);
   const lastDay = clamp(currentDay + RESULT_COUNT - 1, 0, 0xffff);
 
   return rngTools.mirage_island_calculate(initialSeed, currentDay, lastDay);
@@ -108,7 +105,12 @@ const getFields = (values: FormState) => {
   if (values.battery === "Live") {
     fields.push({
       label: "Rocket Launched",
-      input: <FormikInput<FormState> name="rocketLaunchedCount" />,
+      input: (
+        <FormikNumberInput<FormState>
+          name="rocketLaunchedCount"
+          numType="decimal"
+        />
+      ),
     });
   }
   return fields;

--- a/src/rngToolsUi/gen3/sid.tsx
+++ b/src/rngToolsUi/gen3/sid.tsx
@@ -1,20 +1,12 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
   Field,
 } from "~/components";
 import { rngTools } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 
 type GeneratorResult = { sid: number };
 
@@ -27,35 +19,39 @@ const columns: ResultColumn<GeneratorResult>[] = [
 ];
 
 export type FormState = {
-  tid: DecimalString;
-  feebasSeed: HexString;
-  initialAdvances: DecimalString;
-  maxAdvances: DecimalString;
+  tid: number;
+  feebasSeed: number;
+  initialAdvances: number;
+  maxAdvances: number;
 };
 
 const initialValues: FormState = {
-  tid: toDecimalString(14223),
-  feebasSeed: toHexString(0xa4fd),
-  initialAdvances: toDecimalString(0),
-  maxAdvances: toDecimalString(10000),
+  tid: 14223,
+  feebasSeed: 0xa4fd,
+  initialAdvances: 0,
+  maxAdvances: 10000,
 };
 
 const fields: Field[] = [
   {
     label: "TID",
-    input: <FormikInput<FormState> name="tid" />,
+    input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
   },
   {
     label: "Feebas Seed",
-    input: <FormikInput<FormState> name="feebasSeed" />,
+    input: <FormikNumberInput<FormState> name="feebasSeed" numType="hex" />,
   },
   {
     label: "Initial Advances",
-    input: <FormikInput<FormState> name="initialAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="initialAdvances" numType="decimal" />
+    ),
   },
   {
     label: "Max Advances",
-    input: <FormikInput<FormState> name="maxAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="maxAdvances" numType="decimal" />
+    ),
   },
 ];
 
@@ -68,30 +64,16 @@ export const Gen3Sid = ({ game }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const tid = fromDecimalString(opts.tid);
-      const feebasSeed = fromHexString(opts.feebasSeed);
-      const initialAdvances = fromDecimalString(opts.initialAdvances);
-      const maxAdvances = fromDecimalString(opts.maxAdvances);
-
-      if (
-        tid == null ||
-        feebasSeed == null ||
-        initialAdvances == null ||
-        maxAdvances == null
-      ) {
-        return;
-      }
-
       const generate =
         game === "rs"
           ? rngTools.rs_sid_from_feebas_seed
           : rngTools.emerald_sid_from_feebas_seed;
 
       const results = await generate(
-        tid,
-        feebasSeed,
-        initialAdvances,
-        maxAdvances,
+        opts.tid,
+        opts.feebasSeed,
+        opts.initialAdvances,
+        opts.maxAdvances,
       );
 
       setResults([...results].map(({ sid }) => ({ sid })));

--- a/src/rngToolsUi/gen3/static/staticGenerator.tsx
+++ b/src/rngToolsUi/gen3/static/staticGenerator.tsx
@@ -1,21 +1,13 @@
 import { rngTools, Static3GeneratorResult, Species } from "~/rngTools";
 import {
   Field,
-  FormikInput,
+  FormikNumberInput,
   FormikSelect,
   FormikSwitch,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
 } from "~/components";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 import React from "react";
 import { getPkmFilterFields, PkmFilterFields } from "~/components/pkmFilter";
 import {
@@ -49,12 +41,12 @@ const columns: ResultColumn<Result>[] = [
 ];
 
 type FormState = {
-  offset: DecimalString;
-  seed: HexString;
-  initial_advances: DecimalString;
-  max_advances: DecimalString;
-  tid: DecimalString;
-  sid: DecimalString;
+  offset: number;
+  seed: number;
+  initial_advances: number;
+  max_advances: number;
+  tid: number;
+  sid: number;
   species: Species;
   roamer: boolean;
   method4: boolean;
@@ -62,12 +54,12 @@ type FormState = {
 
 const getInitialValues = (game: Static3Game): FormState => {
   return {
-    offset: toDecimalString(0),
-    seed: toHexString(0),
-    initial_advances: toDecimalString(100),
-    max_advances: toDecimalString(1000),
-    tid: toDecimalString(0),
-    sid: toDecimalString(0),
+    offset: 0,
+    seed: 0,
+    initial_advances: 0,
+    max_advances: 0,
+    tid: 0,
+    sid: 0,
     species: getStatic3Species(game)[0],
     roamer: false,
     method4: false,
@@ -85,15 +77,15 @@ const getFields = (game: Static3Game): Field[] => {
   return [
     {
       label: "Seed",
-      input: <FormikInput<FormState> name="seed" />,
+      input: <FormikNumberInput<FormState> name="seed" numType="hex" />,
     },
     {
       label: "TID",
-      input: <FormikInput<FormState> name="tid" />,
+      input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
     },
     {
       label: "SID",
-      input: <FormikInput<FormState> name="sid" />,
+      input: <FormikNumberInput<FormState> name="sid" numType="decimal" />,
     },
     {
       label: "Species",
@@ -116,15 +108,22 @@ const getFields = (game: Static3Game): Field[] => {
     },
     {
       label: "Initial advances",
-      input: <FormikInput<FormState> name="initial_advances" />,
+      input: (
+        <FormikNumberInput<FormState>
+          name="initial_advances"
+          numType="decimal"
+        />
+      ),
     },
     {
       label: "Max advances",
-      input: <FormikInput<FormState> name="max_advances" />,
+      input: (
+        <FormikNumberInput<FormState> name="max_advances" numType="decimal" />
+      ),
     },
     {
       label: "Offset",
-      input: <FormikInput<FormState> name="offset" />,
+      input: <FormikNumberInput<FormState> name="offset" numType="decimal" />,
     },
     ...getPkmFilterFields(),
   ];
@@ -141,32 +140,8 @@ export const Static3Generator = ({ game = "emerald" }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const initialAdvances = fromDecimalString(opts.initial_advances);
-      const maxAdvances = fromDecimalString(opts.max_advances);
-      const seed = fromHexString(opts.seed);
-      const offset = fromDecimalString(opts.offset);
-      const tid = fromDecimalString(opts.tid);
-      const sid = fromDecimalString(opts.sid);
-
-      if (
-        initialAdvances == null ||
-        maxAdvances == null ||
-        seed == null ||
-        offset == null ||
-        tid == null ||
-        sid == null
-      ) {
-        return;
-      }
-
       const results = await rngTools.gen3_static_generator_states({
         ...opts,
-        initial_advances: initialAdvances,
-        max_advances: maxAdvances,
-        seed,
-        offset,
-        tid,
-        sid,
         bugged_roamer: game !== "emerald" && opts.roamer,
         filter: {
           shiny: opts.filter_shiny,

--- a/src/rngToolsUi/gen3/static/staticSearcher.tsx
+++ b/src/rngToolsUi/gen3/static/staticSearcher.tsx
@@ -1,18 +1,13 @@
 import { rngTools, Species, Static3SearcherResult } from "~/rngTools";
 import {
   Field,
-  FormikInput,
+  FormikNumberInput,
   FormikSelect,
   FormikSwitch,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
 } from "~/components";
-import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
 import { getPkmFilterFields, PkmFilterFields } from "~/components/pkmFilter";
 import {
   getStatic3Species,
@@ -56,8 +51,8 @@ const columns: ResultColumn<Result>[] = [
 ];
 
 type FormState = {
-  tid: DecimalString;
-  sid: DecimalString;
+  tid: number;
+  sid: number;
   species: Species;
   roamer: boolean;
   method4: boolean;
@@ -65,8 +60,8 @@ type FormState = {
 
 const getInitialValues = (game: Static3Game): FormState => {
   return {
-    tid: toDecimalString(0),
-    sid: toDecimalString(0),
+    tid: 0,
+    sid: 0,
     species: getStatic3Species(game)[0],
     roamer: false,
     method4: false,
@@ -84,11 +79,11 @@ const getFields = (game: Static3Game): Field[] => {
   return [
     {
       label: "TID",
-      input: <FormikInput<FormState> name="tid" />,
+      input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
     },
     {
       label: "SID",
-      input: <FormikInput<FormState> name="sid" />,
+      input: <FormikNumberInput<FormState> name="sid" numType="decimal" />,
     },
     {
       label: "Species",
@@ -124,17 +119,8 @@ export const Static3Searcher = ({ game }: Props) => {
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
-      const tid = fromDecimalString(opts.tid);
-      const sid = fromDecimalString(opts.sid);
-
-      if (tid == null || sid == null) {
-        return;
-      }
-
       const results = await rngTools.gen3_static_searcher_states({
         ...opts,
-        tid,
-        sid,
         bugged_roamer: game !== "emerald" && opts.roamer,
         filter: {
           shiny: opts.filter_shiny,

--- a/src/rngToolsUi/gen4/dpptIdFinder.tsx
+++ b/src/rngToolsUi/gen4/dpptIdFinder.tsx
@@ -1,17 +1,12 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
   Field,
 } from "~/components";
 import { rngTools, Id4 } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
 import { denormalizeIdFilterOrDefault } from "~/types/id";
 import dayjs, { Dayjs } from "dayjs";
 import { FormikDatePicker, FormikTimePicker } from "~/components/datePicker";
@@ -48,25 +43,25 @@ const columns: ResultColumn<Id4>[] = [
 ];
 
 type FormState = {
-  tid: DecimalString;
+  tid: number;
   date: Dayjs;
   time: Dayjs;
-  minDelay: DecimalString;
-  maxDelay: DecimalString;
+  minDelay: number;
+  maxDelay: number;
 };
 
 const initialValues: FormState = {
-  tid: toDecimalString(0),
+  tid: 0,
   date: dayjs(),
   time: dayjs(),
-  minDelay: toDecimalString(5000),
-  maxDelay: toDecimalString(6000),
+  minDelay: 5000,
+  maxDelay: 6000,
 };
 
 const fields: Field[] = [
   {
     label: "Tid Obtained",
-    input: <FormikInput<FormState> name="tid" />,
+    input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
   },
   {
     label: "Date",
@@ -78,11 +73,11 @@ const fields: Field[] = [
   },
   {
     label: "Min Delay",
-    input: <FormikInput<FormState> name="minDelay" />,
+    input: <FormikNumberInput<FormState> name="minDelay" numType="decimal" />,
   },
   {
     label: "Max Delay",
-    input: <FormikInput<FormState> name="maxDelay" />,
+    input: <FormikNumberInput<FormState> name="maxDelay" numType="decimal" />,
   },
 ];
 
@@ -90,14 +85,6 @@ export const DpptIdFinder = () => {
   const [results, setResults] = React.useState<Id4[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const tid = fromDecimalString(opts.tid);
-    const minDelay = fromDecimalString(opts.minDelay);
-    const maxDelay = fromDecimalString(opts.maxDelay);
-
-    if (tid == null || minDelay == null || maxDelay == null) {
-      return;
-    }
-
     const datetime = dayjs(opts.date)
       .set("hour", opts.time.hour())
       .set("minute", opts.time.minute())
@@ -106,12 +93,12 @@ export const DpptIdFinder = () => {
 
     const results = await rngTools.generate_dppt_ids({
       datetime: rngDateTime,
-      min_delay: minDelay,
-      max_delay: maxDelay,
+      min_delay: opts.minDelay,
+      max_delay: opts.maxDelay,
       filter: denormalizeIdFilterOrDefault({
         type: "tid",
         value0: opts.tid,
-        value1: "",
+        value1: undefined,
       }),
     });
 

--- a/src/rngToolsUi/gen4/dpptIdSearcher.tsx
+++ b/src/rngToolsUi/gen4/dpptIdSearcher.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
@@ -8,11 +8,6 @@ import {
   FormikIdFilter,
 } from "~/components";
 import { rngTools, Id4 } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
 import { denormalizeIdFilterOrDefault, IdFilter } from "~/types/id";
 
 const columns: ResultColumn<Id4>[] = [
@@ -46,35 +41,35 @@ const columns: ResultColumn<Id4>[] = [
 ];
 
 type FormState = {
-  year: DecimalString;
-  minDelay: DecimalString;
-  maxDelay: DecimalString;
+  year: number;
+  min_delay: number;
+  max_delay: number;
   filter: IdFilter;
 };
 
 const initialValues: FormState = {
-  year: toDecimalString(2000),
-  minDelay: toDecimalString(5000),
-  maxDelay: toDecimalString(6000),
+  year: 2000,
+  min_delay: 5000,
+  max_delay: 6000,
   filter: {
     type: "tid",
-    value0: toDecimalString(0),
-    value1: "",
+    value0: 0,
+    value1: undefined,
   },
 };
 
 const fields: Field[] = [
   {
     label: "Year",
-    input: <FormikInput<FormState> name="year" />,
+    input: <FormikNumberInput<FormState> name="year" numType="decimal" />,
   },
   {
     label: "Min Delay",
-    input: <FormikInput<FormState> name="minDelay" />,
+    input: <FormikNumberInput<FormState> name="min_delay" numType="decimal" />,
   },
   {
     label: "Max Delay",
-    input: <FormikInput<FormState> name="maxDelay" />,
+    input: <FormikNumberInput<FormState> name="max_delay" numType="decimal" />,
   },
   {
     label: "Filter",
@@ -86,18 +81,8 @@ export const DpptIdSearcher = () => {
   const [results, setResults] = React.useState<Id4[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const year = fromDecimalString(opts.year);
-    const minDelay = fromDecimalString(opts.minDelay);
-    const maxDelay = fromDecimalString(opts.maxDelay);
-
-    if (year == null || minDelay == null || maxDelay == null) {
-      return;
-    }
-
     const results = await rngTools.search_dppt_ids({
-      year,
-      min_delay: minDelay,
-      max_delay: maxDelay,
+      ...opts,
       filter: denormalizeIdFilterOrDefault(opts.filter),
     });
 
@@ -111,7 +96,7 @@ export const DpptIdSearcher = () => {
       results={results}
       initialValues={initialValues}
       onSubmit={onSubmit}
-      submitTrackerId="generate_oras_id"
+      submitTrackerId="search_dppt_id"
     />
   );
 };

--- a/src/rngToolsUi/gen4/dpptSeedCalibrate.tsx
+++ b/src/rngToolsUi/gen4/dpptSeedCalibrate.tsx
@@ -1,17 +1,12 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
   Field,
 } from "~/components";
 import { rngTools, SeedTime4, SeedTime4Calibrate } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  toDecimalString,
-} from "~/utils/number";
 import dayjs, { Dayjs } from "dayjs";
 import {
   formatRngDateTime,
@@ -51,9 +46,9 @@ const columns: ResultColumn<SeedTime4Calibrate>[] = [
 type FormState = {
   date: Dayjs;
   time: Dayjs;
-  delay: DecimalString;
-  delayCalibration: DecimalString;
-  secondCalibration: DecimalString;
+  delay: number;
+  delay_calibration: number;
+  second_calibration: number;
 };
 
 const fields: Field[] = [
@@ -67,15 +62,27 @@ const fields: Field[] = [
   },
   {
     label: "Searcher Result Delay",
-    input: <FormikInput<FormState> name="delay" disabled />,
+    input: (
+      <FormikNumberInput<FormState> name="delay" disabled numType="decimal" />
+    ),
   },
   {
     label: "Delay Calibration +/-",
-    input: <FormikInput<FormState> name="delayCalibration" />,
+    input: (
+      <FormikNumberInput<FormState>
+        name="delay_calibration"
+        numType="decimal"
+      />
+    ),
   },
   {
     label: "Second Calibration +/-",
-    input: <FormikInput<FormState> name="secondCalibration" />,
+    input: (
+      <FormikNumberInput<FormState>
+        name="second_calibration"
+        numType="decimal"
+      />
+    ),
   },
 ];
 
@@ -86,42 +93,27 @@ type Props = {
 export const DpptSeedCalibrate = ({ selectedSeedTime }: Props) => {
   const [results, setResults] = React.useState<SeedTime4Calibrate[]>([]);
 
-  const initialValues: FormState = React.useMemo(() => {
-    const delayCalibration = toDecimalString(0);
-    const secondCalibration = toDecimalString(0);
-
+  const initialValues = React.useMemo((): FormState => {
     if (selectedSeedTime == null) {
       return {
         date: dayjs(),
         time: dayjs(),
-        delay: toDecimalString(0),
-        delayCalibration,
-        secondCalibration,
+        delay: 0,
+        delay_calibration: 0,
+        second_calibration: 0,
       };
     }
 
     return {
       date: fromRngDateTime(selectedSeedTime.datetime),
       time: fromRngDateTime(selectedSeedTime.datetime),
-      delay: toDecimalString(selectedSeedTime.delay),
-      delayCalibration,
-      secondCalibration,
+      delay: selectedSeedTime.delay,
+      delay_calibration: 0,
+      second_calibration: 0,
     };
   }, [selectedSeedTime]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const delay = fromDecimalString(opts.delay);
-    const delayCalibration = fromDecimalString(opts.delayCalibration);
-    const secondCalibration = fromDecimalString(opts.secondCalibration);
-
-    if (
-      delay == null ||
-      delayCalibration == null ||
-      secondCalibration == null
-    ) {
-      return;
-    }
-
     const datetime = dayjs(opts.date)
       .set("hour", opts.time.hour())
       .set("minute", opts.time.minute())
@@ -131,12 +123,12 @@ export const DpptSeedCalibrate = ({ selectedSeedTime }: Props) => {
     const results = await rngTools.dppt_calibrate_seedtime(
       {
         datetime: rngDateTime,
-        delay,
+        delay: opts.delay,
         coin_flips: [],
       },
       {
-        delay_calibration: delayCalibration,
-        second_calibration: secondCalibration,
+        delay_calibration: opts.delay_calibration,
+        second_calibration: opts.second_calibration,
         entei_route: undefined,
         lati_route: undefined,
         raikou_route: undefined,

--- a/src/rngToolsUi/gen4/dpptSeedSearch.tsx
+++ b/src/rngToolsUi/gen4/dpptSeedSearch.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
   Field,
 } from "~/components";
 import { rngTools, SeedTime4 } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toHexString,
-} from "~/utils/number";
 import dayjs, { Dayjs } from "dayjs";
 import { fromRngDateTime, toRngDateTime } from "~/utils/time";
 import { FormikDatePicker } from "~/components/datePicker";
@@ -43,21 +36,21 @@ const columns: ResultColumn<GeneratorResult>[] = [
 ];
 
 type FormState = {
-  seed: HexString;
+  seed: number;
   date: Dayjs;
-  forcedSecond: DecimalString | "";
+  forced_second: number | undefined;
 };
 
 const initialValues: FormState = {
-  seed: toHexString(0),
+  seed: 0,
   date: dayjs(),
-  forcedSecond: "",
+  forced_second: undefined,
 };
 
 const fields: Field[] = [
   {
     label: "Seed",
-    input: <FormikInput<FormState> name="seed" />,
+    input: <FormikNumberInput<FormState> name="seed" numType="hex" />,
   },
   {
     label: "Year/Month",
@@ -65,7 +58,9 @@ const fields: Field[] = [
   },
   {
     label: "Forced Second",
-    input: <FormikInput<FormState> name="forcedSecond" />,
+    input: (
+      <FormikNumberInput<FormState> name="forced_second" numType="decimal" />
+    ),
   },
 ];
 
@@ -77,21 +72,12 @@ export const DpptSeedSearch = ({ onClickResultRow }: Props) => {
   const [results, setResults] = React.useState<GeneratorResult[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const seed = fromHexString(opts.seed);
-    const forcedSecond =
-      opts.forcedSecond === "" ? null : fromDecimalString(opts.forcedSecond);
-
-    if (seed == null) {
-      return;
-    }
-
     const rngDate = toRngDateTime(opts.date);
 
     const results = await rngTools.dppt_calculate_seedtime({
-      seed,
+      ...opts,
       year: rngDate.year,
       month: rngDate.month,
-      forced_second: forcedSecond ?? undefined,
     });
 
     setResults(results.map((result) => ({ ...result, id: uniqueId() })));

--- a/src/rngToolsUi/gen6/orasId.tsx
+++ b/src/rngToolsUi/gen6/orasId.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
@@ -9,14 +9,6 @@ import {
   FormikSwitch,
 } from "~/components";
 import { rngTools, Gen6Id } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 import { denormalizeIdFilter, IdFilter } from "~/types/id";
 import dayjs, { Dayjs } from "dayjs";
 import { FormikDatePicker, FormikTimePicker } from "~/components/datePicker";
@@ -70,33 +62,33 @@ const columns: ResultColumn<Gen6Id>[] = [
 ];
 
 export type FormState = {
-  seed: HexString;
+  seed: number;
   date: Dayjs;
   time: Dayjs;
-  onlyCurrentSeed: boolean;
-  initialAdvances: DecimalString;
-  maxAdvances: DecimalString;
+  only_current_seed: boolean;
+  initial_advances: number;
+  max_advances: number;
   filter: IdFilter;
 };
 
 const initialValues: FormState = {
-  seed: toHexString(0),
+  seed: 0,
   date: dayjs(),
   time: dayjs(),
-  onlyCurrentSeed: false,
-  initialAdvances: toDecimalString(20),
-  maxAdvances: toDecimalString(50),
+  only_current_seed: false,
+  initial_advances: 20,
+  max_advances: 50,
   filter: {
     type: "tid",
-    value0: toDecimalString(0),
-    value1: "",
+    value0: 0,
+    value1: undefined,
   },
 };
 
 const fields: Field[] = [
   {
     label: "TinyMT u32 Seed",
-    input: <FormikInput<FormState> name="seed" />,
+    input: <FormikNumberInput<FormState> name="seed" numType="hex" />,
   },
   {
     label: "Boot Date",
@@ -108,16 +100,20 @@ const fields: Field[] = [
   },
   {
     label: "Initial Advances",
-    input: <FormikInput<FormState> name="initialAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="initial_advances" numType="decimal" />
+    ),
   },
   {
     label: "Max Advances",
-    input: <FormikInput<FormState> name="maxAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="max_advances" numType="decimal" />
+    ),
   },
   {
     label: "Only Current Seed",
     input: (
-      <FormikSwitch<FormState, "onlyCurrentSeed"> name="onlyCurrentSeed" />
+      <FormikSwitch<FormState, "only_current_seed"> name="only_current_seed" />
     ),
   },
   {
@@ -130,14 +126,6 @@ export const OrasId = () => {
   const [results, setResults] = React.useState<Gen6Id[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const seed = fromHexString(opts.seed);
-    const initialAdvances = fromDecimalString(opts.initialAdvances);
-    const maxAdvances = fromDecimalString(opts.maxAdvances);
-
-    if (seed == null || initialAdvances == null || maxAdvances == null) {
-      return;
-    }
-
     const datetime = dayjs(opts.date)
       .set("hour", opts.time.hour())
       .set("minute", opts.time.minute())
@@ -145,11 +133,11 @@ export const OrasId = () => {
     const rngDateTime = toRngDateTime(datetime);
 
     const results = await rngTools.generate_oras_id({
-      start_seed: seed,
-      only_start_seed: opts.onlyCurrentSeed,
+      start_seed: opts.seed,
+      only_start_seed: opts.only_current_seed,
+      initial_advances: opts.initial_advances,
+      max_advances: opts.max_advances,
       start_datetime: rngDateTime,
-      initial_advances: initialAdvances,
-      max_advances: maxAdvances,
       filter_id: denormalizeIdFilter(opts.filter) ?? undefined,
     });
 

--- a/src/rngToolsUi/gen6/orasMirageSpot.tsx
+++ b/src/rngToolsUi/gen6/orasMirageSpot.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
@@ -8,14 +8,6 @@ import {
   FormikSelect,
 } from "~/components";
 import { rngTools, MirageSpot, Species } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 import dayjs, { Dayjs } from "dayjs";
 import { formatRngDate, toRngDate } from "~/utils/time";
 import { FormikDatePicker } from "~/components/datePicker";
@@ -41,39 +33,39 @@ const columns: ResultColumn<MirageSpot>[] = [
 ];
 
 export type FormState = {
-  seed: HexString;
-  tid: DecimalString;
-  startDate: Dayjs;
-  maxAdvances: DecimalString;
-  filterSpecies: Species;
+  seed: number;
+  tid: number;
+  start_date: Dayjs;
+  max_advances: number;
+  filter_species: Species;
 };
 
 const initialValues: FormState = {
-  seed: toHexString(0),
-  tid: toDecimalString(0),
-  startDate: dayjs(),
-  maxAdvances: toDecimalString(1000),
-  filterSpecies: "None",
+  seed: 0,
+  tid: 0,
+  start_date: dayjs(),
+  max_advances: 1000,
+  filter_species: "None",
 };
 
 const fields: Field[] = [
   {
     label: "Seed",
-    input: <FormikInput<FormState> name="seed" />,
+    input: <FormikNumberInput<FormState> name="seed" numType="hex" />,
   },
   {
     label: "TID",
-    input: <FormikInput<FormState> name="tid" />,
+    input: <FormikNumberInput<FormState> name="tid" numType="decimal" />,
   },
   {
     label: "Save Date",
-    input: <FormikDatePicker<FormState> name="startDate" />,
+    input: <FormikDatePicker<FormState> name="start_date" />,
   },
   {
     label: "Species",
     input: (
-      <FormikSelect<FormState, "filterSpecies">
-        name="filterSpecies"
+      <FormikSelect<FormState, "filter_species">
+        name="filter_species"
         options={(
           [
             "None",
@@ -123,7 +115,13 @@ const fields: Field[] = [
   },
   {
     label: "Max Advances",
-    input: <FormikInput<FormState> name="maxAdvances" disabled />,
+    input: (
+      <FormikNumberInput<FormState>
+        name="max_advances"
+        disabled
+        numType="decimal"
+      />
+    ),
   },
 ];
 
@@ -131,27 +129,11 @@ export const OrAsMirageSpot = () => {
   const [results, setResults] = React.useState<MirageSpot[]>([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const seed = fromHexString(opts.seed);
-    const tid = fromDecimalString(opts.tid);
-    const startDate = toRngDate(opts.startDate);
-    const maxAdvances = fromDecimalString(opts.maxAdvances);
-
-    if (
-      seed == null ||
-      tid == null ||
-      startDate == null ||
-      maxAdvances == null
-    ) {
-      return;
-    }
-
     const results = await rngTools.generate_mirage_spots({
-      seed,
-      tid,
-      start_date: startDate,
-      max_advances: maxAdvances,
+      ...opts,
+      start_date: toRngDate(opts.start_date),
       filter_species:
-        opts.filterSpecies === "None" ? undefined : opts.filterSpecies,
+        opts.filter_species === "None" ? undefined : opts.filter_species,
     });
 
     setResults(results);

--- a/src/rngToolsUi/gen6/xyPokeRadar/index.tsx
+++ b/src/rngToolsUi/gen6/xyPokeRadar/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   ResultColumn,
   RngToolForm,
   RngToolSubmit,
@@ -13,14 +13,6 @@ import {
   PokeRadarChainState,
   PokeRadarPatch,
 } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-  toDecimalString,
-  toHexString,
-} from "~/utils/number";
 import { PokeRadarPatches } from "./patch";
 
 type ChainResult = {
@@ -93,71 +85,77 @@ const noChainColumns: ResultColumn<LooseColumns>[] = [
 ];
 
 export type FormState = {
-  state3: HexString;
-  state2: HexString;
-  state1: HexString;
-  state0: HexString;
-  partyCount: DecimalString;
-  initialAdvances: DecimalString;
-  maxAdvances: DecimalString;
-  chain: DecimalString;
-  bonusMusic: boolean;
-  filterShiny: boolean;
+  state3: number;
+  state2: number;
+  state1: number;
+  state0: number;
+  party_count: number;
+  initial_advances: number;
+  max_advances: number;
+  chain: number;
+  bonus_music: boolean;
+  filter_shiny: boolean;
 };
 
 const initialValues: FormState = {
-  state3: toHexString(0),
-  state2: toHexString(0),
-  state1: toHexString(0),
-  state0: toHexString(0),
-  partyCount: toDecimalString(1),
-  initialAdvances: toDecimalString(0),
-  maxAdvances: toDecimalString(0),
-  chain: toDecimalString(0),
-  bonusMusic: false,
-  filterShiny: false,
+  state3: 0,
+  state2: 0,
+  state1: 0,
+  state0: 0,
+  party_count: 1,
+  initial_advances: 0,
+  max_advances: 0,
+  chain: 0,
+  bonus_music: false,
+  filter_shiny: false,
 };
 
 const fields: Field[] = [
   {
     label: "State[3]",
-    input: <FormikInput<FormState> name="state3" />,
+    input: <FormikNumberInput<FormState> name="state3" numType="hex" />,
   },
   {
     label: "State[2]",
-    input: <FormikInput<FormState> name="state2" />,
+    input: <FormikNumberInput<FormState> name="state2" numType="hex" />,
   },
   {
     label: "State[1]",
-    input: <FormikInput<FormState> name="state1" />,
+    input: <FormikNumberInput<FormState> name="state1" numType="hex" />,
   },
   {
     label: "State[0]",
-    input: <FormikInput<FormState> name="state0" />,
+    input: <FormikNumberInput<FormState> name="state0" numType="hex" />,
   },
   {
     label: "Initial Advances",
-    input: <FormikInput<FormState> name="initialAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="initial_advances" numType="decimal" />
+    ),
   },
   {
     label: "Max Advances",
-    input: <FormikInput<FormState> name="maxAdvances" />,
+    input: (
+      <FormikNumberInput<FormState> name="max_advances" numType="decimal" />
+    ),
   },
   {
     label: "Party Count",
-    input: <FormikInput<FormState> name="partyCount" />,
+    input: (
+      <FormikNumberInput<FormState> name="party_count" numType="decimal" />
+    ),
   },
   {
     label: "Chain",
-    input: <FormikInput<FormState> name="chain" />,
+    input: <FormikNumberInput<FormState> name="chain" numType="decimal" />,
   },
   {
     label: "Bonus Music",
-    input: <FormikSwitch<FormState, "bonusMusic"> name="bonusMusic" />,
+    input: <FormikSwitch<FormState, "bonus_music"> name="bonus_music" />,
   },
   {
     label: "Filter Shiny",
-    input: <FormikSwitch<FormState, "filterShiny"> name="filterShiny" />,
+    input: <FormikSwitch<FormState, "filter_shiny"> name="filter_shiny" />,
   },
 ];
 
@@ -170,36 +168,14 @@ export const XyPokeRadar = () => {
   >([]);
 
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(async (opts) => {
-    const state3 = fromHexString(opts.state3);
-    const state2 = fromHexString(opts.state2);
-    const state1 = fromHexString(opts.state1);
-    const state0 = fromHexString(opts.state0);
-    const initialAdvances = fromDecimalString(opts.initialAdvances);
-    const maxAdvances = fromDecimalString(opts.maxAdvances);
-    const partyCount = fromDecimalString(opts.partyCount);
-    const chain = fromDecimalString(opts.chain);
-
-    if (
-      state3 == null ||
-      state2 == null ||
-      state1 == null ||
-      state0 == null ||
-      initialAdvances == null ||
-      maxAdvances == null ||
-      partyCount == null ||
-      chain == null
-    ) {
-      return;
-    }
-
     const results = await rngTools.generate_poke_radar_states({
-      state: [state0, state1, state2, state3],
-      initial_advances: initialAdvances,
-      max_advances: maxAdvances,
-      party_count: partyCount,
-      chain,
-      bonus_music: opts.bonusMusic,
-      filter_shiny: opts.filterShiny,
+      state: [opts.state0, opts.state1, opts.state2, opts.state3],
+      initial_advances: opts.initial_advances,
+      max_advances: opts.max_advances,
+      party_count: opts.party_count,
+      chain: opts.chain,
+      bonus_music: opts.bonus_music,
+      filter_shiny: opts.filter_shiny,
       filter_slot: undefined,
     });
 

--- a/src/rngToolsUi/timer/gen3.tsx
+++ b/src/rngToolsUi/timer/gen3.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   RngToolForm,
   RngToolSubmit,
   Field,
   FormikSelect,
 } from "~/components";
 import {
-  toDecimalString,
-  fromDecimalString,
   capPrecision,
-  ZodDecimalString,
+  ZodSerializedDecimal,
+  ZodSerializedOptional,
 } from "~/utils/number";
 import { Flex, MultiTimer } from "~/components";
 import { rngTools, ZodConsole } from "~/rngTools";
@@ -30,20 +29,20 @@ const timerStateAtom = atomWithPersistence("gen3Timer", TimerStateSchema, {
 
 const FormStateSchema = z.object({
   console: ZodConsole,
-  preTimer: ZodDecimalString,
-  targetFrame: ZodDecimalString,
-  calibration: ZodDecimalString,
-  frameHit: z.union([ZodDecimalString, z.literal("")]),
+  preTimer: ZodSerializedDecimal,
+  targetFrame: ZodSerializedDecimal,
+  calibration: ZodSerializedDecimal,
+  frameHit: ZodSerializedOptional(ZodSerializedDecimal),
 });
 
 export type FormState = z.infer<typeof FormStateSchema>;
 
 const initialValues: FormState = {
   console: "Gba",
-  preTimer: toDecimalString(5000),
-  targetFrame: toDecimalString(1000),
-  calibration: toDecimalString(0.0),
-  frameHit: "",
+  preTimer: 5000,
+  targetFrame: 1000,
+  calibration: 0.0,
+  frameHit: undefined,
 };
 
 const timerSettingsAtom = atomWithPersistence(
@@ -70,19 +69,19 @@ const fields: Field[] = [
   },
   {
     label: "Pre-Timer",
-    input: <FormikInput<FormState> name="preTimer" />,
+    input: <FormikNumberInput<FormState> name="preTimer" numType="float" />,
   },
   {
     label: "Target Frame",
-    input: <FormikInput<FormState> name="targetFrame" />,
+    input: <FormikNumberInput<FormState> name="targetFrame" numType="float" />,
   },
   {
     label: "Calibration",
-    input: <FormikInput<FormState> name="calibration" />,
+    input: <FormikNumberInput<FormState> name="calibration" numType="float" />,
   },
   {
     label: "Frame Hit",
-    input: <FormikInput<FormState> name="frameHit" />,
+    input: <FormikNumberInput<FormState> name="frameHit" numType="float" />,
   },
 ];
 
@@ -95,14 +94,13 @@ export const Gen3Timer = () => {
       let updatedOpts = opts;
       let settings = {
         console: opts.console,
-        pre_timer: fromDecimalString(opts.preTimer) ?? 0,
-        target_frame: fromDecimalString(opts.targetFrame) ?? 0,
-        calibration: fromDecimalString(opts.calibration) ?? 0,
+        pre_timer: opts.preTimer,
+        target_frame: opts.targetFrame,
+        calibration: opts.calibration,
       };
 
-      if (opts.frameHit !== "") {
-        const frameHit = fromDecimalString(opts.frameHit) ?? 0;
-        settings = await rngTools.calibrate_gen3_timer(settings, frameHit);
+      if (opts.frameHit != null) {
+        settings = await rngTools.calibrate_gen3_timer(settings, opts.frameHit);
         settings = {
           console: opts.console,
           pre_timer: capPrecision(settings.pre_timer),
@@ -111,10 +109,10 @@ export const Gen3Timer = () => {
         };
         updatedOpts = {
           console: settings.console,
-          preTimer: toDecimalString(settings.pre_timer),
-          targetFrame: toDecimalString(settings.target_frame),
-          calibration: toDecimalString(settings.calibration),
-          frameHit: "",
+          preTimer: settings.pre_timer,
+          targetFrame: settings.target_frame,
+          calibration: settings.calibration,
+          frameHit: undefined,
         };
         formik.setValues(updatedOpts);
       }

--- a/src/rngToolsUi/timer/gen4.tsx
+++ b/src/rngToolsUi/timer/gen4.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   RngToolForm,
   RngToolSubmit,
   Field,
@@ -8,9 +8,8 @@ import {
 } from "~/components";
 import {
   capPrecision,
-  fromDecimalString,
-  toDecimalString,
-  ZodDecimalString,
+  ZodSerializedDecimal,
+  ZodSerializedOptional,
 } from "~/utils/number";
 import { Flex, MultiTimer } from "~/components";
 import { rngTools, ZodConsole } from "~/rngTools";
@@ -30,24 +29,24 @@ const timerStateAtom = atomWithPersistence("gen4Timer", TimerStateSchema, {
 
 const FormStateSchema = z.object({
   console: ZodConsole,
-  minTimeMs: ZodDecimalString,
-  calibratedDelay: ZodDecimalString,
-  calibratedSeconds: ZodDecimalString,
-  targetDelay: ZodDecimalString,
-  targetSeconds: ZodDecimalString,
-  delayHit: z.union([ZodDecimalString, z.literal("")]),
+  minTimeMs: ZodSerializedDecimal,
+  calibratedDelay: ZodSerializedDecimal,
+  calibratedSeconds: ZodSerializedDecimal,
+  targetDelay: ZodSerializedDecimal,
+  targetSeconds: ZodSerializedDecimal,
+  delayHit: ZodSerializedOptional(ZodSerializedDecimal),
 });
 
 export type FormState = z.infer<typeof FormStateSchema>;
 
 const defaultValues: FormState = {
   console: "NdsSlot1",
-  minTimeMs: toDecimalString(14000),
-  calibratedDelay: toDecimalString(500),
-  calibratedSeconds: toDecimalString(14),
-  targetDelay: toDecimalString(600),
-  targetSeconds: toDecimalString(50),
-  delayHit: "",
+  minTimeMs: 14000,
+  calibratedDelay: 500,
+  calibratedSeconds: 14,
+  targetDelay: 600,
+  targetSeconds: 50,
+  delayHit: undefined,
 };
 
 const timerSettingsAtom = atomWithPersistence(
@@ -72,27 +71,33 @@ const fields: Field[] = [
   },
   {
     label: "Min Time (ms)",
-    input: <FormikInput<FormState> name="minTimeMs" />,
+    input: <FormikNumberInput<FormState> name="minTimeMs" numType="float" />,
   },
   {
     label: "Calibrated Delay",
-    input: <FormikInput<FormState> name="calibratedDelay" />,
+    input: (
+      <FormikNumberInput<FormState> name="calibratedDelay" numType="float" />
+    ),
   },
   {
     label: "Calibrated Seconds",
-    input: <FormikInput<FormState> name="calibratedSeconds" />,
+    input: (
+      <FormikNumberInput<FormState> name="calibratedSeconds" numType="float" />
+    ),
   },
   {
     label: "Target Delay",
-    input: <FormikInput<FormState> name="targetDelay" />,
+    input: <FormikNumberInput<FormState> name="targetDelay" numType="float" />,
   },
   {
     label: "Target Seconds",
-    input: <FormikInput<FormState> name="targetSeconds" />,
+    input: (
+      <FormikNumberInput<FormState> name="targetSeconds" numType="float" />
+    ),
   },
   {
     label: "Delay Hit",
-    input: <FormikInput<FormState> name="delayHit" />,
+    input: <FormikNumberInput<FormState> name="delayHit" numType="float" />,
   },
 ];
 
@@ -105,16 +110,15 @@ export const Gen4Timer = () => {
       let updatedOpts = opts;
       let settings = {
         console: opts.console,
-        min_time_ms: fromDecimalString(opts.minTimeMs) ?? 0,
-        calibrated_delay: fromDecimalString(opts.calibratedDelay) ?? 0,
-        target_delay: fromDecimalString(opts.targetDelay) ?? 0,
-        target_second: fromDecimalString(opts.targetSeconds) ?? 0,
-        calibrated_second: fromDecimalString(opts.calibratedSeconds) ?? 0,
+        min_time_ms: opts.minTimeMs,
+        calibrated_delay: opts.calibratedDelay,
+        target_delay: opts.targetDelay,
+        target_second: opts.targetSeconds,
+        calibrated_second: opts.calibratedSeconds,
       };
 
-      if (opts.delayHit !== "") {
-        const delayHit = fromDecimalString(opts.delayHit) ?? 0;
-        settings = await rngTools.calibrate_gen4_timer(settings, delayHit);
+      if (opts.delayHit != null) {
+        settings = await rngTools.calibrate_gen4_timer(settings, opts.delayHit);
         settings = {
           console: opts.console,
           min_time_ms: capPrecision(settings.min_time_ms),
@@ -125,12 +129,12 @@ export const Gen4Timer = () => {
         };
         updatedOpts = {
           console: settings.console,
-          minTimeMs: toDecimalString(settings.min_time_ms),
-          calibratedDelay: toDecimalString(settings.calibrated_delay),
-          calibratedSeconds: toDecimalString(settings.calibrated_second),
-          targetDelay: toDecimalString(settings.target_delay),
-          targetSeconds: toDecimalString(settings.target_second),
-          delayHit: "",
+          minTimeMs: settings.min_time_ms,
+          calibratedDelay: settings.calibrated_delay,
+          calibratedSeconds: settings.calibrated_second,
+          targetDelay: settings.target_delay,
+          targetSeconds: settings.target_second,
+          delayHit: undefined,
         };
         formik.setValues(updatedOpts);
       }

--- a/src/rngToolsUi/timer/gen5/entralinkPlus.tsx
+++ b/src/rngToolsUi/timer/gen5/entralinkPlus.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   RngToolForm,
   RngToolSubmit,
   Field,
   FormikSelect,
 } from "~/components";
 import {
-  toDecimalString,
-  fromDecimalString,
   capPrecision,
-  ZodDecimalString,
+  ZodSerializedDecimal,
+  ZodSerializedOptional,
 } from "~/utils/number";
 import { Flex, MultiTimer } from "~/components";
 import {
@@ -38,32 +37,32 @@ const timerStateAtom = atomWithPersistence(
 
 const FormStateSchema = z.object({
   console: ZodConsole,
-  minTimeMs: ZodDecimalString,
-  targetDelay: ZodDecimalString,
-  targetSecond: ZodDecimalString,
-  targetAdvance: ZodDecimalString,
-  calibration: ZodDecimalString,
-  entralinkCalibration: ZodDecimalString,
-  frameCalibration: ZodDecimalString,
-  delayHit: z.union([ZodDecimalString, z.literal("")]),
-  secondHit: z.union([ZodDecimalString, z.literal("")]),
-  advanceHit: z.union([ZodDecimalString, z.literal("")]),
+  minTimeMs: ZodSerializedDecimal,
+  targetDelay: ZodSerializedDecimal,
+  targetSecond: ZodSerializedDecimal,
+  targetAdvance: ZodSerializedDecimal,
+  calibration: ZodSerializedDecimal,
+  entralinkCalibration: ZodSerializedDecimal,
+  frameCalibration: ZodSerializedDecimal,
+  delayHit: ZodSerializedOptional(ZodSerializedDecimal),
+  secondHit: ZodSerializedOptional(ZodSerializedDecimal),
+  advanceHit: ZodSerializedOptional(ZodSerializedDecimal),
 });
 
 export type FormState = z.infer<typeof FormStateSchema>;
 
 const initialValues: FormState = {
   console: "NdsSlot1",
-  minTimeMs: toDecimalString(14000),
-  targetDelay: toDecimalString(1200),
-  targetSecond: toDecimalString(50),
-  targetAdvance: toDecimalString(100),
-  calibration: toDecimalString(-95),
-  entralinkCalibration: toDecimalString(256),
-  frameCalibration: toDecimalString(0),
-  delayHit: "",
-  secondHit: "",
-  advanceHit: "",
+  minTimeMs: 14000,
+  targetDelay: 1200,
+  targetSecond: 50,
+  targetAdvance: 100,
+  calibration: -95,
+  entralinkCalibration: 256,
+  frameCalibration: 0,
+  delayHit: undefined,
+  secondHit: undefined,
+  advanceHit: undefined,
 };
 
 const timerSettingsAtom = atomWithPersistence(
@@ -88,43 +87,52 @@ const fields: Field[] = [
   },
   {
     label: "Min Time (ms)",
-    input: <FormikInput<FormState> name="minTimeMs" />,
+    input: <FormikNumberInput<FormState> name="minTimeMs" numType="float" />,
   },
   {
     label: "Target Delay",
-    input: <FormikInput<FormState> name="targetDelay" />,
+    input: <FormikNumberInput<FormState> name="targetDelay" numType="float" />,
   },
   {
     label: "Target Second",
-    input: <FormikInput<FormState> name="targetSecond" />,
+    input: <FormikNumberInput<FormState> name="targetSecond" numType="float" />,
   },
   {
     label: "Target Advance",
-    input: <FormikInput<FormState> name="targetAdvance" />,
+    input: (
+      <FormikNumberInput<FormState> name="targetAdvance" numType="float" />
+    ),
   },
   {
     label: "Calibration",
-    input: <FormikInput<FormState> name="calibration" />,
+    input: <FormikNumberInput<FormState> name="calibration" numType="float" />,
   },
   {
     label: "Entralink Calibration",
-    input: <FormikInput<FormState> name="entralinkCalibration" />,
+    input: (
+      <FormikNumberInput<FormState>
+        name="entralinkCalibration"
+        numType="float"
+      />
+    ),
   },
   {
     label: "Frame Calibration",
-    input: <FormikInput<FormState> name="frameCalibration" />,
+    input: (
+      <FormikNumberInput<FormState> name="frameCalibration" numType="float" />
+    ),
   },
   {
     label: "Delay Hit",
-    input: <FormikInput<FormState> name="delayHit" />,
+    input: <FormikNumberInput<FormState> name="delayHit" numType="float" />,
   },
   {
     label: "Second Hit",
-    input: <FormikInput<FormState> name="secondHit" />,
+    input: <FormikNumberInput<FormState> name="secondHit" numType="float" />,
   },
   {
     label: "Advance Hit",
-    input: <FormikInput<FormState> name="advanceHit" />,
+    input: <FormikNumberInput<FormState> name="advanceHit" numType="float" />,
   },
 ];
 
@@ -137,29 +145,25 @@ export const Gen5EntralinkPlusTimer = () => {
       let updatedOpts = opts;
       let settings: Gen5EntralinkPlusTimerSettings = {
         console: opts.console,
-        min_time_ms: fromDecimalString(opts.minTimeMs) ?? 0,
-        target_delay: fromDecimalString(opts.targetDelay) ?? 0,
-        target_second: fromDecimalString(opts.targetSecond) ?? 0,
-        target_advances: fromDecimalString(opts.targetAdvance) ?? 0,
-        calibration: fromDecimalString(opts.calibration) ?? 0,
-        entralink_calibration:
-          fromDecimalString(opts.entralinkCalibration) ?? 0,
-        frame_calibration: fromDecimalString(opts.frameCalibration) ?? 0,
+        min_time_ms: opts.minTimeMs,
+        target_delay: opts.targetDelay,
+        target_second: opts.targetSecond,
+        target_advances: opts.targetAdvance,
+        calibration: opts.calibration,
+        entralink_calibration: opts.entralinkCalibration,
+        frame_calibration: opts.frameCalibration,
       };
 
       if (
-        opts.secondHit !== "" &&
-        opts.delayHit !== "" &&
-        opts.advanceHit !== ""
+        opts.secondHit != null &&
+        opts.delayHit != null &&
+        opts.advanceHit != null
       ) {
-        const delayHit = fromDecimalString(opts.delayHit) ?? 0;
-        const secondHit = fromDecimalString(opts.secondHit) ?? 0;
-        const advanceHit = fromDecimalString(opts.advanceHit) ?? 0;
         settings = await rngTools.calibrate_gen5_entralink_plus_timer(
           settings,
-          secondHit,
-          delayHit,
-          advanceHit,
+          opts.secondHit,
+          opts.delayHit,
+          opts.advanceHit,
         );
         settings = {
           console: opts.console,
@@ -173,16 +177,16 @@ export const Gen5EntralinkPlusTimer = () => {
         };
         updatedOpts = {
           console: settings.console,
-          minTimeMs: toDecimalString(settings.min_time_ms),
-          targetDelay: toDecimalString(settings.target_delay),
-          targetSecond: toDecimalString(settings.target_second),
-          targetAdvance: toDecimalString(settings.target_advances),
-          calibration: toDecimalString(settings.calibration),
-          entralinkCalibration: toDecimalString(settings.entralink_calibration),
-          frameCalibration: toDecimalString(settings.frame_calibration),
-          delayHit: "",
-          secondHit: "",
-          advanceHit: "",
+          minTimeMs: settings.min_time_ms,
+          targetDelay: settings.target_delay,
+          targetSecond: settings.target_second,
+          targetAdvance: settings.target_advances,
+          calibration: settings.calibration,
+          entralinkCalibration: settings.entralink_calibration,
+          frameCalibration: settings.frame_calibration,
+          delayHit: undefined,
+          secondHit: undefined,
+          advanceHit: undefined,
         };
         formik.setValues(updatedOpts);
       }

--- a/src/rngToolsUi/timer/gen5/standard.tsx
+++ b/src/rngToolsUi/timer/gen5/standard.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import {
-  FormikInput,
+  FormikNumberInput,
   RngToolForm,
   RngToolSubmit,
   Field,
   FormikSelect,
 } from "~/components";
 import {
-  toDecimalString,
-  fromDecimalString,
   capPrecision,
-  ZodDecimalString,
+  ZodSerializedDecimal,
+  ZodSerializedOptional,
 } from "~/utils/number";
 import { Flex, MultiTimer } from "~/components";
 import { rngTools, ZodConsole } from "~/rngTools";
@@ -34,20 +33,20 @@ const timerStateAtom = atomWithPersistence(
 
 const FormStateSchema = z.object({
   console: ZodConsole,
-  minTimeMs: ZodDecimalString,
-  targetSecond: ZodDecimalString,
-  calibration: ZodDecimalString,
-  secondHit: z.union([ZodDecimalString, z.literal("")]),
+  minTimeMs: ZodSerializedDecimal,
+  targetSecond: ZodSerializedDecimal,
+  calibration: ZodSerializedDecimal,
+  secondHit: ZodSerializedOptional(ZodSerializedDecimal),
 });
 
 export type FormState = z.infer<typeof FormStateSchema>;
 
 const initialValues: FormState = {
   console: "NdsSlot1",
-  minTimeMs: toDecimalString(14000),
-  targetSecond: toDecimalString(50),
-  calibration: toDecimalString(-95),
-  secondHit: "",
+  minTimeMs: 14000,
+  targetSecond: 50,
+  calibration: -95,
+  secondHit: undefined,
 };
 
 const timerSettingsAtom = atomWithPersistence(
@@ -72,19 +71,19 @@ const fields: Field[] = [
   },
   {
     label: "Min Time (ms)",
-    input: <FormikInput<FormState> name="minTimeMs" />,
+    input: <FormikNumberInput<FormState> name="minTimeMs" numType="float" />,
   },
   {
     label: "Target Second",
-    input: <FormikInput<FormState> name="targetSecond" />,
+    input: <FormikNumberInput<FormState> name="targetSecond" numType="float" />,
   },
   {
     label: "Calibration",
-    input: <FormikInput<FormState> name="calibration" />,
+    input: <FormikNumberInput<FormState> name="calibration" numType="float" />,
   },
   {
     label: "Second Hit",
-    input: <FormikInput<FormState> name="secondHit" />,
+    input: <FormikNumberInput<FormState> name="secondHit" numType="float" />,
   },
 ];
 
@@ -97,16 +96,15 @@ export const Gen5StandardTimer = () => {
       let updatedOpts = opts;
       let settings = {
         console: opts.console,
-        min_time_ms: fromDecimalString(opts.minTimeMs) ?? 0,
-        target_second: fromDecimalString(opts.targetSecond) ?? 0,
-        calibration: fromDecimalString(opts.calibration) ?? 0,
+        min_time_ms: opts.minTimeMs,
+        target_second: opts.targetSecond,
+        calibration: opts.calibration,
       };
 
-      if (opts.secondHit !== "") {
-        const secondHit = fromDecimalString(opts.secondHit) ?? 0;
+      if (opts.secondHit != null) {
         settings = await rngTools.calibrate_gen5_standard_timer(
           settings,
-          secondHit,
+          opts.secondHit,
         );
         settings = {
           console: opts.console,
@@ -116,10 +114,10 @@ export const Gen5StandardTimer = () => {
         };
         updatedOpts = {
           console: settings.console,
-          minTimeMs: toDecimalString(settings.min_time_ms),
-          targetSecond: toDecimalString(settings.target_second),
-          calibration: toDecimalString(settings.calibration),
-          secondHit: "",
+          minTimeMs: settings.min_time_ms,
+          targetSecond: settings.target_second,
+          calibration: settings.calibration,
+          secondHit: undefined,
         };
         formik.setValues(updatedOpts);
       }

--- a/src/types/id.ts
+++ b/src/types/id.ts
@@ -1,47 +1,41 @@
 import { IdFilter as RngToolsIdFilter } from "~/rngTools";
-import {
-  DecimalString,
-  fromDecimalString,
-  fromHexString,
-  HexString,
-} from "~/utils/number";
 import { match } from "ts-pattern";
 
 export type IdFilter =
   | {
       type: "none";
-      value0: "";
-      value1: "";
+      value0: undefined;
+      value1: undefined;
     }
   | {
       type: "tid";
-      value0: DecimalString;
-      value1: "";
+      value0: number;
+      value1: undefined;
     }
   | {
       type: "sid";
-      value0: DecimalString;
-      value1: "";
+      value0: number;
+      value1: undefined;
     }
   | {
       type: "pid";
-      value0: HexString;
-      value1: "";
+      value0: number;
+      value1: undefined;
     }
   | {
       type: "tsv";
-      value0: DecimalString;
-      value1: "";
+      value0: number;
+      value1: undefined;
     }
   | {
       type: "tidsid";
-      value0: DecimalString;
-      value1: DecimalString;
+      value0: number;
+      value1: number;
     }
   | {
       type: "tidpid";
-      value0: DecimalString;
-      value1: HexString;
+      value0: number;
+      value1: number;
     };
 
 export const denormalizeIdFilter = (
@@ -50,27 +44,27 @@ export const denormalizeIdFilter = (
   return match<IdFilter, RngToolsIdFilter | null>(value)
     .with({ type: "none" }, () => null)
     .with({ type: "tid" }, ({ value0 }) => ({
-      Tid: fromDecimalString(value0) ?? 0,
+      Tid: value0,
     }))
     .with({ type: "sid" }, ({ value0 }) => ({
-      Sid: fromDecimalString(value0) ?? 0,
+      Sid: value0,
     }))
     .with({ type: "pid" }, ({ value0 }) => ({
-      Pid: fromHexString(value0) ?? 0,
+      Pid: value0,
     }))
     .with({ type: "tsv" }, ({ value0 }) => ({
-      Tsv: fromDecimalString(value0) ?? 0,
+      Tsv: value0,
     }))
     .with({ type: "tidsid" }, ({ value0, value1 }) => ({
       TidSid: {
-        tid: fromDecimalString(value0) ?? 0,
-        sid: fromDecimalString(value1) ?? 0,
+        tid: value0,
+        sid: value1,
       },
     }))
     .with({ type: "tidpid" }, ({ value0, value1 }) => ({
       TidPid: {
-        tid: fromDecimalString(value0) ?? 0,
-        pid: fromHexString(value1) ?? 0,
+        tid: value0,
+        pid: value1,
       },
     }))
     .exhaustive();

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,4 +1,28 @@
 import { z } from "zod";
+import { isNumber } from "lodash-es";
+
+export const ZodSerializedOptional = <Schema extends z.ZodTypeAny>(
+  schema: Schema,
+) =>
+  z
+    .union([schema, z.literal("")])
+    .transform((arg): z.infer<Schema> | undefined => {
+      if (arg === "") {
+        return undefined;
+      }
+
+      return arg;
+    });
+
+export const ZodSerializedDecimal = z
+  .union([z.number(), z.string()])
+  .transform((arg) => (isNumber(arg) ? arg : parseFloat(arg)))
+  .refine((num) => !isNaN(num));
+
+export const ZodSerializedHex = z
+  .union([z.number(), z.string()])
+  .transform((arg) => (isNumber(arg) ? arg : parseInt(arg, 16)))
+  .refine((num) => !isNaN(num));
 
 export const ZodDecimalString = z
   .string()


### PR DESCRIPTION
HexString and DecimalString were originally added to ensure we handled numbers correctly while using a generic input component.  This allowed some flexibility with how inputs were handled while initial tools were built and patterns were established.

Now that patterns have solidified and we have a common set of inputs for several tools, it's time we create specific components and remove HexString and DecimalString.

This should clean up a fair amount of code, and paves the way for validation, such as `minValue`/`maxValue`.