### PR TITLE
Fix for too many parameters warning

### DIFF
--- a/rng_tools/src/generators/gen2/celebi.rs
+++ b/rng_tools/src/generators/gen2/celebi.rs
@@ -1,5 +1,5 @@
 use super::poke::{Poke, SpecialTrait, possible_special_trait};
-use super::{Gen2PokeFilter, Gen2Spread};
+use super::{DivParams, Gen2PokeFilter, Gen2Spread};
 use crate::rng::gameboy::{Div, GameboyRng, Offset};
 use wasm_bindgen::prelude::*;
 
@@ -62,18 +62,14 @@ fn has_potential_special_celebi(rng: &GameboyRng) -> SpecialTrait {
 
 #[wasm_bindgen]
 pub fn crystal_generate_celebi(
-    adiv: u8,
-    sdiv: u8,
-    adiv_index: usize,
-    sdiv_index: usize,
-    state: u16,
+    config: DivParams,
     start_advance: usize,
     end_advance: usize,
     filter: Gen2PokeFilter,
 ) -> Vec<Gen2Spread> {
-    let add_div = Div::new(adiv_index, adiv);
-    let sub_div = Div::new(sdiv_index, sdiv);
-    let mut rng = GameboyRng::new(state, add_div, sub_div);
+    let add_div = Div::new(config.adiv_index, config.adiv);
+    let sub_div = Div::new(config.sdiv_index, config.sdiv);
+    let mut rng = GameboyRng::new(config.state, add_div, sub_div);
     let mut spreads = Vec::new();
     for advance in start_advance..=end_advance {
         let special_trait = has_potential_special_celebi(&rng);

--- a/rng_tools/src/generators/gen2/mod.rs
+++ b/rng_tools/src/generators/gen2/mod.rs
@@ -17,6 +17,16 @@ pub struct Gen2Spread {
     pub max_dv: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct DivParams {
+    pub adiv: u8,
+    pub sdiv: u8,
+    pub adiv_index: usize,
+    pub sdiv_index: usize,
+    pub state: u16,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum Gen2PokeFilter {

--- a/rng_tools/src/generators/gen2/starter.rs
+++ b/rng_tools/src/generators/gen2/starter.rs
@@ -1,5 +1,5 @@
 use super::poke::{Poke, SpecialTrait, possible_special_trait};
-use super::{Gen2PokeFilter, Gen2Spread};
+use super::{DivParams, Gen2PokeFilter, Gen2Spread};
 use crate::rng::gameboy::{Div, GameboyRng, Offset};
 use wasm_bindgen::prelude::*;
 
@@ -73,18 +73,14 @@ fn has_potential_special_starter(rng: &GameboyRng) -> SpecialTrait {
 
 #[wasm_bindgen]
 pub fn crystal_generate_starters(
-    adiv: u8,
-    sdiv: u8,
-    adiv_index: usize,
-    sdiv_index: usize,
-    state: u16,
+    config: DivParams,
     start_advance: usize,
     end_advance: usize,
     filter: Gen2PokeFilter,
 ) -> Vec<Gen2Spread> {
-    let add_div = Div::new(adiv_index, adiv);
-    let sub_div = Div::new(sdiv_index, sdiv);
-    let mut rng = GameboyRng::new(state, add_div, sub_div);
+    let add_div = Div::new(config.adiv_index, config.adiv);
+    let sub_div = Div::new(config.sdiv_index, config.sdiv);
+    let mut rng = GameboyRng::new(config.state, add_div, sub_div);
     let mut spreads = Vec::new();
     for advance in start_advance..=end_advance {
         let special_trait = has_potential_special_starter(&rng);

--- a/src/rngToolsUi/gen2/crystalPokemon.tsx
+++ b/src/rngToolsUi/gen2/crystalPokemon.tsx
@@ -8,7 +8,7 @@ import {
   RngToolSubmit,
   Field,
 } from "~/components";
-import { rngTools, type Gen2Spread } from "~/rngTools";
+import { rngTools, type Gen2Spread, type DivParams } from "~/rngTools";
 import { useTranslator, Translations, Translator } from "~/utils/siteLanguage";
 import { z } from "zod";
 import { HexSchema } from "~/utils/number";
@@ -179,14 +179,6 @@ type Props = {
   language: keyof typeof translations;
 };
 
-export interface DivParams {
-  adiv: number;
-  sdiv: number;
-  adiv_index: number;
-  sdiv_index: number;
-  state: number;
-}
-
 export const Gen2PokemonRng = ({ type, language }: Props) => {
   const t = useTranslator(translations, language);
   const fields = React.useMemo(() => getFields(t), [t]);
@@ -199,7 +191,7 @@ export const Gen2PokemonRng = ({ type, language }: Props) => {
           ? rngTools.crystal_generate_starters
           : rngTools.crystal_generate_celebi;
 
-      const config = {
+      const config: DivParams = {
         adiv: opts.div >>> 8,
         sdiv: opts.div & 0xff,
         adiv_index: opts.adivIndex,

--- a/src/rngToolsUi/gen2/crystalPokemon.tsx
+++ b/src/rngToolsUi/gen2/crystalPokemon.tsx
@@ -179,12 +179,19 @@ type Props = {
   language: keyof typeof translations;
 };
 
+export interface DivParams {
+  adiv: number;
+  sdiv: number;
+  adiv_index: number;
+  sdiv_index: number;
+  state: number;
+}
+
 export const Gen2PokemonRng = ({ type, language }: Props) => {
   const t = useTranslator(translations, language);
   const fields = React.useMemo(() => getFields(t), [t]);
   const columns = React.useMemo(() => getColumns(t), [t]);
   const [results, setResults] = React.useState<Gen2Spread[]>([]);
-
   const onSubmit = React.useCallback<RngToolSubmit<FormState>>(
     async (opts) => {
       const generator =
@@ -192,12 +199,15 @@ export const Gen2PokemonRng = ({ type, language }: Props) => {
           ? rngTools.crystal_generate_starters
           : rngTools.crystal_generate_celebi;
 
+      const config = {
+        adiv: opts.div >>> 8,
+        sdiv: opts.div & 0xff,
+        adiv_index: opts.adivIndex,
+        sdiv_index: opts.sdivIndex,
+        state: opts.state,
+      };
       const results = await generator(
-        opts.div >>> 8,
-        opts.div & 0xff,
-        opts.adivIndex,
-        opts.sdivIndex,
-        opts.state,
+        config,
         opts.startAdvance,
         opts.startAdvance + opts.advanceCount,
         opts.filter,


### PR DESCRIPTION
Implements a Struct called DivParams to lower parameters in celebi rng function and updates typescript to accept the change as well. no change to functions, just moving variables around basically.

I can quickly add this to gen 2 starters as well before merge if wanted which would remove another warning from cargo clippy.

To make sure it didn't cause any change to how functions were being done i did test it in my local environment, that it produces the same advance and state information as what the site does currently.

I did make sure to run cargo test and etc as well but if it looks like i missed anything please let me know.

Also apologies for the double pull request for same thing. Closed out the other so only the related commits would be on this one.