### PR TITLE
Add Dream Radar Patches Guide

### DIFF
--- a/guides/Tools and Emulators/Dream Radar Patches.mdx
+++ b/guides/Tools and Emulators/Dream Radar Patches.mdx
@@ -1,0 +1,50 @@
+---
+title: "Dream Radar No-Cart Patch"
+description: "Learn how to patch Pokémon Dream Radar on the 3DS to load saves from TWiLightMenu, nds-bootstrap, or emulators — no game cart needed."
+slug: "dream-radar-patches"
+category: "3DS Tools"
+tag: "cfw"
+---
+
+## Cart Redirect Patch
+
+This patch tricks Dream Radar into thinking a cartridge is inserted by loading a .sav file from the SD card instead.
+
+It allows you to use your save from [TWiLightMenu](https://github.com/DS-Homebrew/TWiLightMenu) or [nds-bootstrap](https://github.com/ahezard/nds-bootstrap). It also lets you use saves from an emulator without needing to inject them.
+
+## Tools
+
+- A 3DS with CFW (Custom Firmware)
+- [Instructions for installing CFW](https://3ds.hacks.guide/)
+
+## Update Luma Settings
+
+1. Boot the console while holding `Select`.
+2. Select "Enable game patches".
+
+## Install the Patch
+
+1. Download and unzip the [zip file](https://github.com/zaksabeast/DreamRadarCartRedirect/releases).
+2. Copy the IPS patch of your choice to the SD card.
+
+   - Japanese: `/luma/titles/0004000000073200`.
+   - All Other Regions: `/luma/titles/00040000000AE100`.
+
+3. Rename the file to `code.ips`.
+
+- For example, if you're playing Dream Radar, you should now have a file at `/luma/titles/00040000000AE100/code.ips`.
+
+## Prepare your save file
+
+1. Make sure you have a save file at `/roms/nds/saves/white2.sav`, `/roms/nds/saves/black2.sav`, `/roms/nds/saves/black.sav`, or `/roms/nds/saves/white.sav`.
+
+2. If using TWiLightMenu, have a game file at `/roms/nds/white2.nds`, `/roms/nds/black2.nds`, `/roms/nds/black.nds`, or `/roms/nds/white.nds`.
+
+If working, Dream Radar should detect the save as if a cart was inserted and allow transfers.
+
+## Troubleshooting
+
+### Error: Cart not inserted
+
+1. Make sure your save file is named correctly and in the right location.
+2. Make sure game patching is enabled in Luma.

--- a/guides/Tools and Emulators/Transporter Patches.mdx
+++ b/guides/Tools and Emulators/Transporter Patches.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Transporter Patches"
-description: "Collection of patches to modify or enhance Pokémon Transporter functionality."
+title: "Pokemon Transporter Offline & Save Patches"
+navDrawerTitle: "Transporter Patches"
+description: "Learn how to patch Pokémon Transporter to work offline and load emulator or TWiLightMenu saves from the SD card."
 slug: "transporter-patches"
 category: "3DS Tools"
 tag: "cfw"
@@ -20,13 +21,20 @@ tag: "cfw"
 
 This patch lets you use Transporter offline and keeps a stable delay for RNGing Pokémon from VC games. PKSM is needed as a destination for the transferred Pokémon.
 
-1. Download the [code.ips file](https://github.com/zaksabeast/Transporter-Offline-Patch/releases) and copy it to the SD card at `/luma/titles/00040000000C9C00/code.ips`.
-2. Open PKSM, enable "Edit during transfers", and create a new bank named `transport`.
-3. Transfer Pokémon using Transporter.
+### Install the patch
 
-```
-Note: For more info, visit the [PKSM wiki](https://github.com/FlagBrew/PKSM/wiki/Storage).
-```
+1. Download the [code.ips file](https://github.com/zaksabeast/Transporter-Offline-Patch/releases) for Transporter.
+2. Copy the file to:
+   - `/luma/titles/00040000000C9C00/code.ips`.
+
+### Set up PKSM
+
+1. Open PKSM and go to storage.
+2. Enable "Edit during transfers" in the settings.
+3. Create a new bank named `transport`.
+4. Transfer Pokémon using Transporter.
+
+- For more info, visit the [PKSM wiki](https://github.com/FlagBrew/PKSM/wiki/Storage).
 
 ### Troubleshooting
 
@@ -40,20 +48,21 @@ A: This may happen if:
 
 ## Cart Redirect Patch
 
-This patch redirects Transporter and Dream Radar to use a .sav file on the SD card instead of a game cartridge. It lets you use saves from an emulator without needing to inject them.
+This patch tricks Transporter into thinking a cartridge is inserted by loading a .sav file from the SD card instead.
+
+It allows you to use your save from [TWiLightMenu](https://github.com/DS-Homebrew/TWiLightMenu) or [nds-bootstrap](https://github.com/ahezard/nds-bootstrap). It also lets you use saves from an emulator without needing to inject them.
+
+### Install the patch
 
 1. Download and unzip the [zip file](https://github.com/zaksabeast/DreamRadarCartRedirect/releases).
-2. Copy the IPS patch of your choice to the SD card.
+2. Copy the IPS patch for Transporter to:
+   - `/luma/titles/00040000000C9C00/code.ips`.
 
-- For Pokémon Transporter: `/luma/titles/00040000000C9C00/code.ips`.
-- For Japanese Pokémon Dream Radar: `/luma/titles/0004000000073200/code.ips`.
-- For All Regions Pokémon Dream Radar: `/luma/titles/00040000000AE100/code.ips`.
+## Prepare your save file
 
-3. Make sure you have a save file at `/roms/nds/saves/white2.sav`, `/roms/nds/saves/black2.sav`, `/roms/nds/saves/black.sav`, or `/roms/nds/saves/white.sav`.
+1. Make sure you have a save file at `/roms/nds/saves/white2.sav`, `/roms/nds/saves/black2.sav`, `/roms/nds/saves/black.sav`, or `/roms/nds/saves/white.sav`.
 
-```
-Note: If using [TWiLightMenu](https://github.com/DS-Homebrew/TWiLightMenu), have a game file at `/roms/nds/white2.nds`, `/roms/nds/black2.nds`, `/roms/nds/black.nds`, or `/roms/nds/white.nds`.
-```
+2. If using TWiLightMenu, have a game file at `/roms/nds/white2.nds`, `/roms/nds/black2.nds`, `/roms/nds/black.nds`, or `/roms/nds/white.nds`.
 
 ```
 Note: Black and White are only supported by Transporter.

--- a/src/__generated__/guides.ts
+++ b/src/__generated__/guides.ts
@@ -529,6 +529,27 @@ export const guides = {
       () => import("~/../guides/Gen 4/Diamond, Pearl, and Platinum/Wild.mdx"),
     ),
   },
+  "/dream-radar-patches": {
+    meta: {
+      title: "Dream Radar No-Cart Patch",
+      navDrawerTitle: "Dream Radar No-Cart Patch",
+      description:
+        "Learn how to patch Pokémon Dream Radar on the 3DS to load saves from TWiLightMenu, nds-bootstrap, or emulators — no game cart needed.",
+      category: "3DS Tools",
+      slug: "/dream-radar-patches",
+      isRoughDraft: false,
+      tag: "cfw",
+      hideFromNavDrawer: false,
+      addedOn: null,
+      translation: null,
+      layout: "guide",
+      file: "guides/Tools and Emulators/Dream Radar Patches.mdx",
+      translations: null,
+    },
+    Guide: React.lazy(
+      () => import("~/../guides/Tools and Emulators/Dream Radar Patches.mdx"),
+    ),
+  },
   "/e-tips-rng": {
     meta: {
       title: "Emerald RNG Info",
@@ -3490,10 +3511,10 @@ export const guides = {
   },
   "/transporter-patches": {
     meta: {
-      title: "Transporter Patches",
+      title: "Pokemon Transporter Offline & Save Patches",
       navDrawerTitle: "Transporter Patches",
       description:
-        "Collection of patches to modify or enhance Pokémon Transporter functionality.",
+        "Learn how to patch Pokémon Transporter to work offline and load emulator or TWiLightMenu saves from the SD card.",
       category: "3DS Tools",
       slug: "/transporter-patches",
       isRoughDraft: false,
@@ -4316,6 +4337,7 @@ export const guideSlugs = [
   "/dppt-pokeradar-rng",
   "/dppt-setup-rng",
   "/dppt-wild",
+  "/dream-radar-patches",
   "/e-tips-rng",
   "/emerald",
   "/emerald-mirage-island",


### PR DESCRIPTION
This PR adds a guide for the Dream Radar no cart patch. It also edits the Transporter patch guide to be for transporter patches only.

This closes #267. 