### PR TITLE
HGSS seed time stuff

### DIFF
--- a/rng_tools/src/generators/gen4/id.rs
+++ b/rng_tools/src/generators/gen4/id.rs
@@ -1,4 +1,4 @@
-use super::{FindSeedTime4Options, SeedTime4, calc_seed, dppt_find_seedtime};
+use super::{DpptSeedTime4, FindSeedTime4Options, calc_seed, dppt_find_seedtime};
 use crate::rng::Rng;
 use crate::rng::mt::MT;
 use crate::{IdFilter, RngDateTime, gen3_tsv};
@@ -18,7 +18,7 @@ pub struct Id4Options {
 #[derive(Debug, Clone, PartialEq, Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct Id4 {
-    pub seed_time: SeedTime4,
+    pub seed_time: DpptSeedTime4,
     pub tid: u16,
     pub sid: u16,
     pub tsv: u16,
@@ -46,7 +46,7 @@ pub fn generate_dppt_ids(opts: Id4Options) -> Vec<Id4> {
 
             if filter.filter_gen3(tid, sid) {
                 results.push(Id4 {
-                    seed_time: SeedTime4::new(seed, datetime.clone(), delay),
+                    seed_time: DpptSeedTime4::new(seed, datetime.clone(), delay),
                     tid,
                     sid,
                     tsv: gen3_tsv(tid, sid),
@@ -130,7 +130,7 @@ mod test {
             tid: 1234,
             sid: 12129,
             tsv: 1398,
-            seed_time: SeedTime4 {
+            seed_time: DpptSeedTime4 {
                 seed: 0x4e16001a,
                 datetime: datetime!(2021-01-01 22:19:58).unwrap(),
                 delay: 5,
@@ -155,7 +155,7 @@ mod test {
             tid: 1234,
             sid: 12129,
             tsv: 1398,
-            seed_time: SeedTime4 {
+            seed_time: DpptSeedTime4 {
                 seed: 0x4e16001a,
                 datetime: datetime!(2021-01-01 22:47:30).unwrap(),
                 delay: 5,
@@ -181,7 +181,7 @@ mod test {
                 tid: 1234,
                 sid: 11608,
                 tsv: 1329,
-                seed_time: SeedTime4 {
+                seed_time: DpptSeedTime4 {
                     seed: 0xa40b13f3,
                     datetime: datetime!(2021-03-23 11:58:37).unwrap(),
                     delay: 5086,
@@ -192,7 +192,7 @@ mod test {
                 tid: 1234,
                 sid: 22909,
                 tsv: 2997,
-                seed_time: SeedTime4 {
+                seed_time: DpptSeedTime4 {
                     seed: 0xb00b1662,
                     datetime: datetime!(2021-03-23 11:58:49).unwrap(),
                     delay: 5709,

--- a/rng_tools/src/generators/gen4/seed_time.rs
+++ b/rng_tools/src/generators/gen4/seed_time.rs
@@ -332,22 +332,22 @@ fn roamer_check(seed: u32, roamer_opts: RoamerSet) -> Vec<RoamerLocation> {
     let mut rng = Pokerng::new(seed);
     let mut results = Vec::new();
 
-    if roamer_opts.raikou == true {
+    if roamer_opts.raikou {
         let mut roamer = RoamerLocation::new(Species::Raikou);
         get_route_j(rng.rand::<u32>(), &mut roamer);
         results.push(roamer)
     }
-    if roamer_opts.entei == true {
+    if roamer_opts.entei {
         let mut roamer = RoamerLocation::new(Species::Entei);
         get_route_j(rng.rand::<u32>(), &mut roamer);
         results.push(roamer)
     }
-    if roamer_opts.latios == true {
+    if roamer_opts.latios {
         let mut roamer = RoamerLocation::new(Species::Latios);
         get_route_k(rng.rand::<u32>(), &mut roamer);
         results.push(roamer)
     }
-    if roamer_opts.latias == true {
+    if roamer_opts.latias {
         let mut roamer = RoamerLocation::new(Species::Latias);
         get_route_k(rng.rand::<u32>(), &mut roamer);
         results.push(roamer)

--- a/rng_tools/src/generators/gen4/seed_time.rs
+++ b/rng_tools/src/generators/gen4/seed_time.rs
@@ -839,20 +839,24 @@ mod test {
             };
             let result = hgss_find_seedtime(opts, roamer);
             let expected = Some(HgssSeedTime4 {
-                seed: 0xaabbccdd,
-                datetime: datetime!(2032-02-26 23:59:59).unwrap(),
-                delay: 10800317,
+                seed: 0xad090311,
+                datetime: datetime!(2032-02-28 09:58:59).unwrap(),
+                delay: 753,
                 roamer: vec![
                     RoamerLocation {
                         roamer: Species::Entei,
-                        location: 10,
+                        location: 39,
                     },
                     RoamerLocation {
                         roamer: Species::Raikou,
-                        location: 10,
+                        location: 42,
+                    },
+                    RoamerLocation {
+                        roamer: Species::Latias,
+                        location: 20,
                     },
                 ],
-                elm: elm_calls!("EKPEKPEKPEKP"),
+                elm: elm_calls!("KKEKKEPKEEEEKEKEEKEP"),
             });
 
             assert_eq!(result, expected);

--- a/rng_tools/src/generators/gen4/stationary/searcher.rs
+++ b/rng_tools/src/generators/gen4/stationary/searcher.rs
@@ -1,4 +1,4 @@
-use crate::gen4::{FindSeedTime4Options, SeedTime4, dppt_find_seedtime};
+use crate::gen4::{DpptSeedTime4, FindSeedTime4Options, dppt_find_seedtime};
 use crate::generators::utils::recover_poke_rng_iv;
 use crate::rng::Rng;
 use crate::{
@@ -28,7 +28,7 @@ pub struct SearchStatic4Method1Opts {
 #[derive(Debug, Clone, PartialEq, Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct SearchStatic4Method1State {
-    pub seed_time: SeedTime4,
+    pub seed_time: DpptSeedTime4,
     pub advance: usize,
     pub pid: u32,
     pub ivs: Ivs,
@@ -73,7 +73,7 @@ impl PkmState for Base4Method1State {
 }
 
 impl Base4Method1State {
-    fn full_state(&self, advance: usize, seed_time: SeedTime4) -> SearchStatic4Method1State {
+    fn full_state(&self, advance: usize, seed_time: DpptSeedTime4) -> SearchStatic4Method1State {
         SearchStatic4Method1State {
             advance,
             seed_time,
@@ -249,7 +249,7 @@ mod tests {
             let expected = [
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x5C03025B,
                         datetime: datetime!(2000-01-01 03:33:58).unwrap(),
                         delay: 603,
@@ -272,7 +272,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xDC03025B,
                         datetime: datetime!(2000-04-26 03:58:58).unwrap(),
                         delay: 603,
@@ -295,7 +295,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0403025B,
                         datetime: datetime!(2000-01-01 03:00:03).unwrap(),
                         delay: 603,
@@ -318,7 +318,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8403025B,
                         datetime: datetime!(2000-01-15 03:59:58).unwrap(),
                         delay: 603,
@@ -341,7 +341,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0003025B,
                         datetime: datetime!(2000-05-28 03:58:58).unwrap(),
                         delay: 603,
@@ -364,7 +364,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8003025B,
                         datetime: datetime!(2000-01-11 03:59:58).unwrap(),
                         delay: 603,
@@ -387,7 +387,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA803025B,
                         datetime: datetime!(2000-02-26 03:58:58).unwrap(),
                         delay: 603,
@@ -410,7 +410,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2803025B,
                         datetime: datetime!(2000-01-01 03:00:39).unwrap(),
                         delay: 603,
@@ -433,7 +433,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA403025B,
                         datetime: datetime!(2000-02-24 03:58:58).unwrap(),
                         delay: 603,
@@ -456,7 +456,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2403025B,
                         datetime: datetime!(2000-01-01 03:00:35).unwrap(),
                         delay: 603,
@@ -479,7 +479,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x52060259,
                         datetime: datetime!(2000-01-01 06:23:58).unwrap(),
                         delay: 601,
@@ -502,7 +502,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xD2060259,
                         datetime: datetime!(2000-03-31 06:59:58).unwrap(),
                         delay: 601,
@@ -525,7 +525,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x3A060259,
                         datetime: datetime!(2000-01-01 06:00:57).unwrap(),
                         delay: 601,
@@ -548,7 +548,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xBA060259,
                         datetime: datetime!(2000-03-23 06:59:58).unwrap(),
                         delay: 601,
@@ -571,7 +571,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x96060259,
                         datetime: datetime!(2000-02-17 06:58:58).unwrap(),
                         delay: 601,
@@ -594,7 +594,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x16060259,
                         datetime: datetime!(2000-01-01 06:00:21).unwrap(),
                         delay: 601,
@@ -617,7 +617,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x7E060259,
                         datetime: datetime!(2000-01-09 06:59:58).unwrap(),
                         delay: 601,
@@ -640,7 +640,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 0,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xFE060259,
                         datetime: datetime!(2000-05-28 06:56:58).unwrap(),
                         delay: 601,
@@ -693,7 +693,7 @@ mod tests {
             let expected = [
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x5C03025B,
                         datetime: datetime!(2000-01-01 03:33:58).unwrap(),
                         delay: 603,
@@ -716,7 +716,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xDC03025B,
                         datetime: datetime!(2000-04-26 03:58:58).unwrap(),
                         delay: 603,
@@ -739,7 +739,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0403025B,
                         datetime: datetime!(2000-01-01 03:00:03).unwrap(),
                         delay: 603,
@@ -762,7 +762,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8403025B,
                         datetime: datetime!(2000-01-15 03:59:58).unwrap(),
                         delay: 603,
@@ -785,7 +785,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0003025B,
                         datetime: datetime!(2000-05-28 03:58:58).unwrap(),
                         delay: 603,
@@ -808,7 +808,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8003025B,
                         datetime: datetime!(2000-01-11 03:59:58).unwrap(),
                         delay: 603,
@@ -831,7 +831,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA803025B,
                         datetime: datetime!(2000-02-26 03:58:58).unwrap(),
                         delay: 603,
@@ -854,7 +854,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2803025B,
                         datetime: datetime!(2000-01-01 03:00:39).unwrap(),
                         delay: 603,
@@ -877,7 +877,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA403025B,
                         datetime: datetime!(2000-02-24 03:58:58).unwrap(),
                         delay: 603,
@@ -900,7 +900,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2403025B,
                         datetime: datetime!(2000-01-01 03:00:35).unwrap(),
                         delay: 603,
@@ -953,7 +953,7 @@ mod tests {
             let expected = [
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x5C03025B,
                         datetime: datetime!(2000-01-03 03:59:30).unwrap(),
                         delay: 603,
@@ -976,7 +976,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xDC03025B,
                         datetime: datetime!(2000-05-27 03:55:30).unwrap(),
                         delay: 603,
@@ -999,7 +999,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0403025B,
                         datetime: datetime!(2000-06-29 03:56:30).unwrap(),
                         delay: 603,
@@ -1022,7 +1022,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8403025B,
                         datetime: datetime!(2000-02-22 03:58:30).unwrap(),
                         delay: 603,
@@ -1045,7 +1045,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x0003025B,
                         datetime: datetime!(2000-06-28 03:58:30).unwrap(),
                         delay: 603,
@@ -1068,7 +1068,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x8003025B,
                         datetime: datetime!(2000-02-20 03:58:30).unwrap(),
                         delay: 603,
@@ -1091,7 +1091,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA803025B,
                         datetime: datetime!(2000-03-27 03:57:30).unwrap(),
                         delay: 603,
@@ -1114,7 +1114,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2803025B,
                         datetime: datetime!(2000-01-01 03:09:30).unwrap(),
                         delay: 603,
@@ -1137,7 +1137,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0xA403025B,
                         datetime: datetime!(2000-03-25 03:59:30).unwrap(),
                         delay: 603,
@@ -1160,7 +1160,7 @@ mod tests {
                 },
                 SearchStatic4Method1State {
                     advance: 2,
-                    seed_time: SeedTime4 {
+                    seed_time: DpptSeedTime4 {
                         seed: 0x2403025B,
                         datetime: datetime!(2000-01-01 03:05:30).unwrap(),
                         delay: 603,


### PR DESCRIPTION
I was hoping I would get to finish this all tonight and not do a draft pull request but it is late now.

Adds:
Roamer location logic for HGSS,
Elm call logic,
functions to call to get hgss seed dates with the elm and roamer data wrapped in instead of coin flips.

as of right now, I just need to double check get_route_k  and elm calls as they cause my test to fail.