### PR TITLE
Add bun run start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "bun run build:rng_tools && bun run scripts/dev-server",
+    "start": "bun run scripts/dev-server",
+    "dev": "bun run build:rng_tools && bun run start",
     "format": "bun run format:ts && bun run format:rust",
     "format:ts": "bun prettier . --write",
     "format:rust": "bun run scripts/format-rust",


### PR DESCRIPTION
bun run dev keeps checking rust code which isn't modified most of the time (~10s overhead each time, polluting the terminal with additional logs).
`bun run start` can now be used to start the server if there are no rust changes.